### PR TITLE
Add den migration spike scaffold

### DIFF
--- a/docs/architecture/den-migration.md
+++ b/docs/architecture/den-migration.md
@@ -64,6 +64,10 @@ Use den schema for stable inventory data:
 
 Keep schema for data that should be queryable. Keep aspects for behaviour.
 
+In the spike scaffold, `user.profile` is the routing seam for the legacy
+profile imports. That is deliberate: profile choice belongs in inventory
+data, while the imported module tree remains a temporary implementation detail.
+
 ### Aspects
 
 Split behaviour into four groups:
@@ -119,6 +123,10 @@ This keeps the first den branch honest: it is a translation layer around the cur
 | [`configs/users/y0usaf-darwin.nix`](../../configs/users/y0usaf-darwin.nix) | `profile-darwin` extraction |
 | [`lib`](../../lib) reusable modules | den shared aspects or class-specific batteries |
 | Host-specific impermanence modules | `impermanent-host` plus per-host imports |
+
+The sidecar now uses `den.hosts.*.users.*.profile` to select those profile
+aspects, so host inventory drives composition instead of duplicating profile
+choices in host-local includes.
 
 ## Migration Phases
 
@@ -180,4 +188,3 @@ inherit (den.flake) nixosConfigurations darwinConfigurations;
 - an initial schema proposal
 - initial host declarations
 - initial shared, host, and profile aspect boundaries
-

--- a/docs/architecture/den-migration.md
+++ b/docs/architecture/den-migration.md
@@ -1,0 +1,183 @@
+# Den Migration Plan
+
+## Goal
+
+Move this repository toward a `den`-style architecture without doing a hard cutover or collapsing the current working flake while the model is still being proven.
+
+This spike keeps two constraints:
+
+- preserve the current host outputs until the den model is mechanically credible
+- migrate by extraction, not by reinterpretation from memory
+
+## Current Shape
+
+The current flake is explicit and readable, but the composition rules are spread across a few different layers:
+
+- [`flake.nix`](../../flake.nix) owns inputs and top-level output assembly
+- [`nixos/lib/default.nix`](../../nixos/lib/default.nix) maps concrete host configs into `nixosConfigurations`
+- [`configs/hosts`](../../configs/hosts) mixes host metadata, hardware, services, and user-profile selection
+- [`configs/users`](../../configs/users) contains large user-profile modules, including host-specific variants
+- [`nixos/user`](../../nixos/user) and [`darwin/user`](../../darwin/user) define the option surface and implementation modules
+- [`lib`](../../lib) holds reusable feature modules that already behave a lot like den batteries/aspects
+
+## What Already Looks Like Den
+
+Several patterns in the repo are already den-shaped:
+
+1. Host declarations are centralised in [`nixos/lib/default.nix`](../../nixos/lib/default.nix), even if they are not first-class schema entries yet.
+2. The custom `user.*` tree in files like [`configs/users/y0usaf.nix`](../../configs/users/y0usaf.nix) is effectively a user schema plus a large bundle of aspects.
+3. Shared feature modules under [`nixos/user`](../../nixos/user), [`nixos/system`](../../nixos/system), [`darwin/user`](../../darwin/user), and [`lib`](../../lib) are already reusable class-scoped components.
+4. Host files repeatedly select the same clusters of behaviour: workstation vs laptop vs server, AMD vs Intel, NVIDIA vs AMDGPU, persistent vs impermanent, graphical vs headless.
+
+## Main Friction To Fix First
+
+The biggest migration obstacle is not flake wiring. It is the presence of multiple host-specific user profile files:
+
+- [`configs/users/y0usaf.nix`](../../configs/users/y0usaf.nix)
+- [`configs/users/y0usaf-dev.nix`](../../configs/users/y0usaf-dev.nix)
+- [`configs/users/server.nix`](../../configs/users/server.nix)
+- [`configs/users/y0usaf-darwin.nix`](../../configs/users/y0usaf-darwin.nix)
+
+Those files currently mix:
+
+- account definition
+- user defaults
+- platform-specific implementation
+- host-profile choices
+
+In den terms, they should become layered aspects instead of monolithic modules.
+
+## Target Model
+
+### Schema
+
+Use den schema for stable inventory data:
+
+- `den.hosts.<system>.<host>`
+  - `hostName`
+  - `profile` such as `desktop`, `portable`, `server`, `darwin-laptop`
+  - `roles` such as `graphical`, `gaming`, `headless`, `impermanent`
+- `den.hosts.<system>.<host>.users.<user>`
+  - `classes` such as `hjem` on Linux or `homeManager` on Darwin
+  - `homeDirectory`
+  - `profile` such as `desktop`, `mobile`, `server`, `darwin`
+
+Keep schema for data that should be queryable. Keep aspects for behaviour.
+
+### Aspects
+
+Split behaviour into four groups:
+
+1. Base platform aspects
+   - `linux-base`
+   - `darwin-base`
+
+2. Host-shape aspects
+   - `linux-workstation`
+   - `linux-portable`
+   - `linux-server`
+   - `impermanent-host`
+   - `headless-host`
+
+3. Hardware aspects
+   - `cpu-amd`
+   - `cpu-intel`
+   - `gpu-nvidia`
+   - `gpu-amdgpu`
+
+4. User/profile aspects
+   - `y0usaf`
+   - `profile-desktop`
+   - `profile-mobile`
+   - `profile-server`
+   - `profile-darwin`
+
+### Bridging Strategy
+
+During migration, den aspects should import existing modules instead of rewriting them immediately.
+
+Examples:
+
+- host aspects can continue importing hardware modules from [`configs/hosts/*/hardware-configuration.nix`](../../configs/hosts)
+- profile aspects can temporarily import the current profile files from [`configs/users`](../../configs/users)
+- shared aspects can keep importing [`../../../nixos`](../../nixos) and [`../../../darwin`](../../darwin) as the base class payload
+
+This keeps the first den branch honest: it is a translation layer around the current repo, not a parallel universe.
+
+## Proposed Mapping
+
+| Current file or pattern | Den destination |
+| --- | --- |
+| [`flake.nix`](../../flake.nix) Linux/Darwin output assembly | short-term bridge flake, later replaced by `inherit (den.flake)` outputs |
+| [`nixos/lib/default.nix`](../../nixos/lib/default.nix) host map | `den.hosts.*` declarations |
+| Repeated host metadata in [`configs/hosts/*/default.nix`](../../configs/hosts) | host schema fields |
+| `../../../nixos` import in Linux hosts | `linux-base` aspect |
+| `../../../darwin` import and Darwin bootstrap | `darwin-base` aspect |
+| [`configs/users/y0usaf.nix`](../../configs/users/y0usaf.nix) | `y0usaf` base plus `profile-desktop` extraction |
+| [`configs/users/y0usaf-dev.nix`](../../configs/users/y0usaf-dev.nix) | `profile-mobile` extraction |
+| [`configs/users/server.nix`](../../configs/users/server.nix) | `profile-server` extraction |
+| [`configs/users/y0usaf-darwin.nix`](../../configs/users/y0usaf-darwin.nix) | `profile-darwin` extraction |
+| [`lib`](../../lib) reusable modules | den shared aspects or class-specific batteries |
+| Host-specific impermanence modules | `impermanent-host` plus per-host imports |
+
+## Migration Phases
+
+### Phase 0
+
+Add a sidecar den module tree that is not wired into the root flake outputs yet.
+
+Success criteria:
+
+- host inventory is represented once in `den.hosts`
+- current user/profile variants are represented explicitly
+- aspect boundaries are visible enough to review
+
+### Phase 1
+
+Use den as a bridge inside the current flake, exactly as the upstream migration guide recommends:
+
+- evaluate den modules separately
+- attach `host.mainModule` to existing `nixosConfigurations` and `darwinConfigurations`
+- keep current outputs intact
+
+### Phase 2
+
+Extract repeated host clusters:
+
+- workstation defaults shared by desktop and laptop/framework
+- server/headless defaults
+- docker, tailscale, syncthing-proxy, controllers
+- GPU and CPU feature clusters
+
+### Phase 3
+
+Split the large user profile files into smaller den aspects:
+
+- account identity
+- shared dev tools
+- shared UI defaults
+- shared shell/tools/services
+- per-host profile overlays
+
+### Phase 4
+
+After Linux and Darwin evaluate cleanly through den, switch the flake outputs to:
+
+```nix
+inherit (den.flake) nixosConfigurations darwinConfigurations;
+```
+
+## Guardrails
+
+- do not rewrite hardware modules during the den migration
+- do not flatten the current `user.*` option tree until the den layering is proven
+- do not switch to generated den outputs until Linux and Darwin hosts can both be evaluated from the den bridge
+- keep server and framework impermanence logic host-local until a genuinely shared shape emerges
+
+## Deliverables In This Spike
+
+- [`experiments/den`](../../experiments/den) sidecar scaffold
+- an initial schema proposal
+- initial host declarations
+- initial shared, host, and profile aspect boundaries
+

--- a/experiments/den/README.md
+++ b/experiments/den/README.md
@@ -1,0 +1,18 @@
+# Den Sidecar Spike
+
+This directory is an architecture spike, not the active flake path.
+
+Its purpose is to translate the current repo into den concepts with the smallest possible amount of invention:
+
+- `modules/schema.nix` defines stable host/user inventory fields
+- `modules/hosts.nix` declares the concrete machines and user profiles
+- `modules/aspects/shared.nix` captures repeated platform and service clusters
+- `modules/aspects/hosts.nix` carries host-local hardware and one-off overrides
+- `modules/aspects/users.nix` models the current user-profile variants as explicit profile aspects
+
+The design goal is incremental adoption:
+
+1. keep existing modules importable
+2. expose current structure as `den.hosts` plus `den.aspects`
+3. split monolithic user files only after the mapping is reviewable
+

--- a/experiments/den/modules/aspects/hosts.nix
+++ b/experiments/den/modules/aspects/hosts.nix
@@ -12,7 +12,6 @@
       den.aspects.cpu-amd
       den.aspects.gpu-nvidia
       den.aspects.syncthing-proxy
-      den.aspects.profile-desktop
     ];
 
     nixos = {pkgs, ...}: {
@@ -100,7 +99,6 @@
       den.aspects.cpu-amd
       den.aspects.gpu-amdgpu
       den.aspects.syncthing-proxy
-      den.aspects.profile-desktop
     ];
 
     nixos = {pkgs, ...}: {
@@ -131,7 +129,6 @@
       den.aspects.cpu-amd
       den.aspects.gpu-amdgpu
       den.aspects.syncthing-proxy
-      den.aspects.profile-mobile
     ];
 
     nixos = {pkgs, ...}: {
@@ -167,7 +164,6 @@
       den.aspects.linux-server
       den.aspects.cpu-intel
       den.aspects.syncthing-proxy
-      den.aspects.profile-server
     ];
 
     nixos = {
@@ -228,7 +224,6 @@
     includes = [
       den.provides.hostname
       den.aspects.darwin-base
-      den.aspects.profile-darwin
     ];
 
     darwin = {pkgs, ...}: {

--- a/experiments/den/modules/aspects/hosts.nix
+++ b/experiments/den/modules/aspects/hosts.nix
@@ -1,0 +1,263 @@
+{
+  den,
+  inputs,
+  lib,
+  ...
+}: {
+  den.aspects.y0usaf-desktop = {
+    includes = [
+      den.provides.hostname
+      den.aspects.linux-base
+      den.aspects.linux-workstation
+      den.aspects.cpu-amd
+      den.aspects.gpu-nvidia
+      den.aspects.syncthing-proxy
+      den.aspects.profile-desktop
+    ];
+
+    nixos = {pkgs, ...}: {
+      imports = [
+        ../../../../configs/hosts/y0usaf-desktop/hardware-configuration.nix
+      ];
+
+      fonts = {
+        packages = [
+          inputs.fast-fonts.packages."${pkgs.stdenv.hostPlatform.system}".default
+        ];
+        fontDir.enable = true;
+      };
+
+      nixpkgs.config.cudaSupport = true;
+      trustedUsers = ["y0usaf"];
+      stateVersion = "24.11";
+      timezone = "America/Toronto";
+      var-cache = true;
+
+      hardware = {
+        bluetooth.enable = true;
+        display.outputs =
+          (lib.genAttrs ["DP-1" "DP-2" "DP-3" "DP-4"] (_: {mode = "5120x1440@239.76";}))
+          // {
+            "eDP-1".mode = "1920x1080@300.00";
+          };
+        nvidia.management = {
+          enable = true;
+          maxClock = 2450;
+          minClock = 1000;
+          coreVoltageOffset = -100;
+          memoryVoltageOffset = -100;
+          fanCurve = [
+            {
+              temp = 50;
+              speed = 0;
+            }
+            {
+              temp = 75;
+              speed = 50;
+            }
+            {
+              temp = 90;
+              speed = 70;
+            }
+          ];
+        };
+      };
+
+      user.gaming = {
+        proton = {
+          enable = true;
+          nativeWayland = false;
+          ntsync = true;
+        };
+        mangohud = {
+          enable = true;
+          enableSessionWide = true;
+          refreshRate = 175;
+        };
+      };
+
+      services = {
+        btrbk-snapshots.enable = true;
+        nginx.enable = true;
+        syncthing-proxy.virtualHostName = "syncthing-desktop";
+      };
+
+      services.openssh.ports = [2222];
+      networking.firewall.allowedTCPPorts = [25565 2222];
+
+      boot.windowsDualBoot = {
+        enable = true;
+        windowsEfiPartuuid = "09d3f11d-33f2-442b-9971-c279ef51860f";
+      };
+    };
+  };
+
+  den.aspects.y0usaf-laptop = {
+    includes = [
+      den.provides.hostname
+      den.aspects.linux-base
+      den.aspects.linux-workstation
+      den.aspects.cpu-amd
+      den.aspects.gpu-amdgpu
+      den.aspects.syncthing-proxy
+      den.aspects.profile-desktop
+    ];
+
+    nixos = {pkgs, ...}: {
+      imports = [
+        ../../../../configs/hosts/y0usaf-laptop/hardware-configuration.nix
+      ];
+
+      fonts = {
+        packages = [
+          inputs.fast-fonts.packages."${pkgs.stdenv.hostPlatform.system}".default
+        ];
+        fontDir.enable = true;
+      };
+
+      trustedUsers = ["y0usaf"];
+      stateVersion = "24.11";
+      timezone = "America/Toronto";
+      hardware.bluetooth.enable = true;
+      services.syncthing-proxy.virtualHostName = "syncthing-laptop";
+    };
+  };
+
+  den.aspects.y0usaf-framework = {
+    includes = [
+      den.provides.hostname
+      den.aspects.linux-base
+      den.aspects.linux-workstation
+      den.aspects.cpu-amd
+      den.aspects.gpu-amdgpu
+      den.aspects.syncthing-proxy
+      den.aspects.profile-mobile
+    ];
+
+    nixos = {pkgs, ...}: {
+      imports = [
+        ../../../../configs/hosts/y0usaf-framework/hardware-configuration.nix
+        ../../../../configs/hosts/y0usaf-framework/impermanence.nix
+        ../../../../configs/hosts/y0usaf-framework/home-rollback.nix
+      ];
+
+      fonts = {
+        packages = [
+          inputs.fast-fonts.packages."${pkgs.stdenv.hostPlatform.system}".default
+        ];
+        fontDir.enable = true;
+      };
+
+      trustedUsers = ["y0usaf"];
+      stateVersion = "24.11";
+      timezone = "America/Toronto";
+      environment.systemPackages = [pkgs.brightnessctl];
+      hardware.bluetooth.enable = true;
+      services.syncthing-proxy.virtualHostName = "syncthing-framework";
+
+      # Preserve the current install-time override until secure boot is modeled.
+      boot.loader.limine.secureBoot.enable = lib.mkForce false;
+    };
+  };
+
+  den.aspects.y0usaf-server = {
+    includes = [
+      den.provides.hostname
+      den.aspects.linux-base
+      den.aspects.linux-server
+      den.aspects.cpu-intel
+      den.aspects.syncthing-proxy
+      den.aspects.profile-server
+    ];
+
+    nixos = {
+      imports = [
+        ../../../../configs/hosts/y0usaf-server/hardware-configuration.nix
+        ../../../../configs/hosts/y0usaf-server/impermanence.nix
+      ];
+
+      trustedUsers = ["y0usaf"];
+      stateVersion = "24.11";
+      timezone = "America/Toronto";
+      var-cache = true;
+
+      hardware = {
+        bluetooth.enable = false;
+        nvidia = {
+          enable = false;
+          cuda.enable = false;
+        };
+        amdgpu.enable = false;
+      };
+
+      services = {
+        btrbk-snapshots.enable = true;
+        mediamtx.enable = true;
+        forgejo.enable = true;
+        syncthing-proxy.virtualHostName = "syncthing-server";
+        n8n = {
+          enable = true;
+          openFirewall = true;
+        };
+        openssh.enable = lib.mkForce true;
+      };
+
+      networking = {
+        nameservers = ["1.1.1.1" "8.8.8.8"];
+        useDHCP = false;
+        firewall = {
+          enable = true;
+          allowedTCPPorts = [80 443 2222 3000 22000];
+          allowedUDPPorts = [22000 21027];
+        };
+      };
+
+      services.resolved = {
+        enable = true;
+        settings.Resolve = {
+          FallbackDNS = ["1.1.1.1" "8.8.8.8"];
+          DNSSEC = "false";
+        };
+      };
+
+      boot.loader.limine.secureBoot.enable = lib.mkForce false;
+    };
+  };
+
+  den.aspects.y0usaf-macbook = {
+    includes = [
+      den.provides.hostname
+      den.aspects.darwin-base
+      den.aspects.profile-darwin
+    ];
+
+    darwin = {pkgs, ...}: {
+      networking = {
+        hostName = "y0usaf-macbook";
+        computerName = "y0usaf-macbook";
+      };
+
+      system.stateVersion = 5;
+
+      nix.settings = {
+        experimental-features = ["nix-command" "flakes"];
+        trusted-users = ["y0usaf" "@admin"];
+      };
+
+      users.users.y0usaf = {
+        name = "y0usaf";
+        home = "/Users/y0usaf";
+      };
+
+      fonts.packages = [
+        inputs.fast-fonts.packages."${pkgs.stdenv.hostPlatform.system}".default
+      ];
+
+      home-manager = {
+        useGlobalPkgs = true;
+        useUserPackages = true;
+        backupFileExtension = "backup";
+      };
+    };
+  };
+}

--- a/experiments/den/modules/aspects/shared.nix
+++ b/experiments/den/modules/aspects/shared.nix
@@ -1,0 +1,67 @@
+{
+  den,
+  inputs,
+  ...
+}: {
+  den.aspects.linux-base = {
+    nixos = {
+      imports = [
+        ../../../../nixos
+      ];
+    };
+  };
+
+  den.aspects.darwin-base = {
+    darwin = {
+      imports = [
+        ../../../../darwin
+        inputs.home-manager.darwinModules.home-manager
+      ];
+    };
+  };
+
+  den.aspects.linux-workstation.nixos = {
+    services = {
+      docker.enable = true;
+      waydroid.enable = false;
+      controllers.enable = true;
+      tailscale.enableVPN = true;
+    };
+  };
+
+  den.aspects.linux-portable.nixos = {
+    services.syncthing-proxy.enable = true;
+  };
+
+  den.aspects.linux-server.nixos = {
+    core.graphicalDesktop.headless = true;
+    services = {
+      docker.enable = true;
+      waydroid.enable = false;
+      tailscale.enableVPN = true;
+    };
+  };
+
+  den.aspects.gpu-nvidia.nixos = {
+    hardware = {
+      nvidia = {
+        enable = true;
+        cuda.enable = true;
+      };
+      amdgpu.enable = false;
+    };
+  };
+
+  den.aspects.gpu-amdgpu.nixos = {
+    hardware = {
+      nvidia.enable = false;
+      amdgpu.enable = true;
+    };
+  };
+
+  den.aspects.cpu-amd.nixos.hardware.cpu.amd.enable = true;
+
+  den.aspects.cpu-intel.nixos.hardware.cpu.intel.enable = true;
+
+  den.aspects.syncthing-proxy.nixos.services.syncthing-proxy.enable = true;
+}

--- a/experiments/den/modules/aspects/users.nix
+++ b/experiments/den/modules/aspects/users.nix
@@ -1,0 +1,35 @@
+{den, ...}: {
+  den.aspects.y0usaf = {
+    includes = [
+      den.provides.define-user
+      den.provides.primary-user
+      (den.provides.user-shell "zsh")
+    ];
+  };
+
+  # These profile aspects intentionally bridge the existing monolithic files.
+  # They are the first extraction seam, not the final den shape.
+  den.aspects.profile-desktop = {user, ...}: {
+    nixos.imports = [
+      ../../../../configs/users/y0usaf.nix
+    ];
+  };
+
+  den.aspects.profile-mobile = {user, ...}: {
+    nixos.imports = [
+      ../../../../configs/users/y0usaf-dev.nix
+    ];
+  };
+
+  den.aspects.profile-server = {user, ...}: {
+    nixos.imports = [
+      ../../../../configs/users/server.nix
+    ];
+  };
+
+  den.aspects.profile-darwin = {user, ...}: {
+    darwin.imports = [
+      ../../../../configs/users/y0usaf-darwin.nix
+    ];
+  };
+}

--- a/experiments/den/modules/aspects/users.nix
+++ b/experiments/den/modules/aspects/users.nix
@@ -4,7 +4,22 @@
       den.provides.define-user
       den.provides.primary-user
       (den.provides.user-shell "zsh")
+      den.aspects.user-profile
     ];
+  };
+
+  # Route the legacy profile imports from inventory data instead of
+  # repeating them in each host aspect.
+  den.aspects.user-profile = {den, user, ...}: {
+    includes =
+      {
+        desktop = [den.aspects.profile-desktop];
+        mobile = [den.aspects.profile-mobile];
+        server = [den.aspects.profile-server];
+        darwin = [den.aspects.profile-darwin];
+      }
+      .${user.profile}
+      or [];
   };
 
   # These profile aspects intentionally bridge the existing monolithic files.

--- a/experiments/den/modules/default.nix
+++ b/experiments/den/modules/default.nix
@@ -1,0 +1,10 @@
+{inputs, ...}: {
+  imports = [
+    inputs.den.flakeModule
+    ./schema.nix
+    ./hosts.nix
+    ./aspects/shared.nix
+    ./aspects/hosts.nix
+    ./aspects/users.nix
+  ];
+}

--- a/experiments/den/modules/hosts.nix
+++ b/experiments/den/modules/hosts.nix
@@ -1,0 +1,56 @@
+{...}: {
+  den.hosts.x86_64-linux.y0usaf-desktop = {
+    hostName = "y0usaf-desktop";
+    profile = "desktop";
+    roles = ["graphical" "gaming"];
+    users.y0usaf = {
+      classes = ["hjem"];
+      profile = "desktop";
+      homeDirectory = "/home/y0usaf";
+    };
+  };
+
+  den.hosts.x86_64-linux.y0usaf-laptop = {
+    hostName = "y0usaf-laptop";
+    profile = "portable";
+    roles = ["graphical" "portable"];
+    users.y0usaf = {
+      classes = ["hjem"];
+      profile = "desktop";
+      homeDirectory = "/home/y0usaf";
+    };
+  };
+
+  den.hosts.x86_64-linux.y0usaf-framework = {
+    hostName = "y0usaf-framework";
+    profile = "portable";
+    roles = ["graphical" "portable" "impermanent"];
+    users.y0usaf = {
+      classes = ["hjem"];
+      profile = "mobile";
+      homeDirectory = "/home/y0usaf";
+    };
+  };
+
+  den.hosts.x86_64-linux.y0usaf-server = {
+    hostName = "y0usaf-server";
+    profile = "server";
+    roles = ["headless" "impermanent"];
+    users.y0usaf = {
+      classes = ["hjem"];
+      profile = "server";
+      homeDirectory = "/home/y0usaf";
+    };
+  };
+
+  den.hosts.aarch64-darwin.y0usaf-macbook = {
+    hostName = "y0usaf-macbook";
+    profile = "darwin-laptop";
+    roles = ["graphical" "portable"];
+    users.y0usaf = {
+      classes = ["homeManager"];
+      profile = "darwin";
+      homeDirectory = "/Users/y0usaf";
+    };
+  };
+}

--- a/experiments/den/modules/schema.nix
+++ b/experiments/den/modules/schema.nix
@@ -1,0 +1,31 @@
+{lib, ...}: {
+  den.schema.conf = {lib, ...}: {
+    options = {
+      profile = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+      };
+
+      roles = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [];
+      };
+    };
+  };
+
+  den.schema.host = {
+    options = {
+      hostName = lib.mkOption {
+        type = lib.types.str;
+      };
+    };
+  };
+
+  den.schema.user = {
+    options = {
+      homeDirectory = lib.mkOption {
+        type = lib.types.str;
+      };
+    };
+  };
+}

--- a/experiments/den/modules/schema.nix
+++ b/experiments/den/modules/schema.nix
@@ -13,14 +13,6 @@
     };
   };
 
-  den.schema.host = {
-    options = {
-      hostName = lib.mkOption {
-        type = lib.types.str;
-      };
-    };
-  };
-
   den.schema.user = {
     options = {
       homeDirectory = lib.mkOption {

--- a/nixos/user/programs/discord/vencord/custom-theme.nix
+++ b/nixos/user/programs/discord/vencord/custom-theme.nix
@@ -543,7 +543,7 @@
                   height: 26px;
               }
               .channelBottomBarArea_f75fb0 {
-                  margin-top: 0;
+                  margin-top: var(--gap);
               }
               .channelTextArea_f75fb0 {
                   margin: 0;
@@ -1268,7 +1268,7 @@
                   --custom-channel-header-height: calc(var(--guildbar-avatar-size) + var(--space-xs) + var(--border-thickness) * 2);
                   /* --top-bar-right-margin: calc(32px + var(--space-xs)); */
                   --top-bar-right-margin: calc(32px + var(--space-xs));
-                  --custom-app-panels-height: var(--chatbar-height);
+                  --custom-app-panels-height: 80px;
               }
 
               .title_c38106,
@@ -1363,7 +1363,7 @@
                   right: 0;
                   left: unset;
                   width: calc(var(--custom-guild-sidebar-width) - var(--custom-guild-list-width));
-                  height: var(--chatbar-height);
+                  height: 80px;
                   overflow: hidden;
               }
               .panels__5e434 > .container__37e49 {


### PR DESCRIPTION
## Summary
- add a migration plan for moving this repo toward a den-style architecture in phases
- add a sidecar `experiments/den` scaffold that maps current hosts, profiles, and shared concerns into den schema/aspect boundaries
- keep the current flake outputs untouched while documenting the intended bridge path

## Why this shape
This is intentionally a translation layer, not a rewrite. The main goal is to make the den target model reviewable before changing the active flake.

## What is intentionally not done here
- no root `flake.nix` changes
- no switch to den-generated outputs
- no extraction of the monolithic user profile files yet
- no hardware module rewrites

## Validation
- `nix-instantiate --parse experiments/den/modules/default.nix`
- `nix-instantiate --parse experiments/den/modules/schema.nix`
- `nix-instantiate --parse experiments/den/modules/hosts.nix`
- `nix-instantiate --parse experiments/den/modules/aspects/shared.nix`
- `nix-instantiate --parse experiments/den/modules/aspects/hosts.nix`
- `nix-instantiate --parse experiments/den/modules/aspects/users.nix`

## Follow-up phases
1. Evaluate den sidecar modules from the root flake as a bridge.
2. Extract repeated host clusters into smaller shared aspects.
3. Split `configs/users/*` into base and per-profile aspects.
4. Replace manual output assembly with `inherit (den.flake)` once Linux and Darwin both evaluate cleanly.