### PR TITLE
feat: add nushell as alternative shell option

### DIFF
--- a/configs/users/y0usaf.nix
+++ b/configs/users/y0usaf.nix
@@ -173,6 +173,7 @@
     };
     shell = {
       zsh.enable = true;
+      nushell.enable = true;
       cat-fetch.enable = true;
       zellij = {
         enable = true;

--- a/configs/users/y0usaf.nix
+++ b/configs/users/y0usaf.nix
@@ -7,7 +7,7 @@
 }: {
   users.users.y0usaf = {
     isNormalUser = true;
-    shell = pkgs.zsh;
+    shell = pkgs.nushell;
     extraGroups = ["wheel" "networkmanager" "video" "audio" "input" "gamemode" "dialout" "bluetooth" "lp" "docker"];
     home = "/home/y0usaf";
     ignoreShellProgramCheck = true;

--- a/flake.lock
+++ b/flake.lock
@@ -9,8 +9,8 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1773515851,
-        "narHash": "sha256-1AaTk0qWLkrUz2yi6g1cACSQChmlQbaGbKlfmbtbb9A=",
+        "lastModified": 1773560100,
+        "narHash": "sha256-rI5CiXpmjSWRhuOP4OQLqPJ+rM6i0QDQtc+PscpEvmM=",
         "path": "/home/y0usaf/Dev/Agent-Harness",
         "type": "path"
       },
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773416489,
-        "narHash": "sha256-Fwo6D/gEVQJlSIns8dFJtFPl7VGTUSfsV+UdphiOmcU=",
+        "lastModified": 1773559575,
+        "narHash": "sha256-MpR8ekGb+Zl8Ngo88pwFF+UljLDU5dNhiXS/Iqn8i1g=",
         "owner": "stablyai",
         "repo": "agent-slack",
-        "rev": "42aa6a10054d3865192fdb18faedf5f9f973f929",
+        "rev": "73cfefc06b44baf609a49ffd17921e1f1c794f42",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773451839,
-        "narHash": "sha256-a7yGiEC2Nh4z7b5aR9sTPDnFOt7ykYQ3yU/MEdhKUWA=",
+        "lastModified": 1773504138,
+        "narHash": "sha256-CQZelDz8KtJBcY88cP9KKpqD5WNYkkwOR2U7RhW53T8=",
         "owner": "sadjow",
         "repo": "claude-code-nix",
-        "rev": "e64e47c888e3eb19d8c58c91046310582634271c",
+        "rev": "57fec627abf180c338ebdf1b0c5230b59e536ce0",
         "type": "github"
       },
       "original": {
@@ -183,11 +183,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773025010,
-        "narHash": "sha256-khlHllTsovXgT2GZ0WxT4+RvuMjNeR5OW0UYeEHPYQo=",
+        "lastModified": 1773506317,
+        "narHash": "sha256-qWKbLUJpavIpvOdX1fhHYm0WGerytFHRoh9lVck6Bh0=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "7b9f7f88ab3b339f8142dc246445abb3c370d3d3",
+        "rev": "878ec37d6a8f52c6c801d0e2a2ad554c75b9353c",
         "type": "github"
       },
       "original": {
@@ -538,11 +538,11 @@
         "scenefx": "scenefx"
       },
       "locked": {
-        "lastModified": 1773464981,
-        "narHash": "sha256-zKlImlnnf+iJeUke2gthzvmXu0cl8P7vBNRwvjkbsN4=",
+        "lastModified": 1773579165,
+        "narHash": "sha256-JBPMZ0YObh1FsbicV8ZNr2k+FS9G7YhlQe/3lROu7wI=",
         "owner": "DreamMaoMao",
         "repo": "mango",
-        "rev": "32c36ba48548f1b30e929c8a739f838bac72db2f",
+        "rev": "5606124da9213c1a5fe6e0947f49ceb17146a4bd",
         "type": "github"
       },
       "original": {
@@ -616,11 +616,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773446705,
-        "narHash": "sha256-IBAHAaYfiR9fhR+y6ZUdM697dht26tvrWeIrTLwBs3E=",
+        "lastModified": 1773578674,
+        "narHash": "sha256-UaO8aE+qRQgglrJbhi9hzSeiP8oob9brLY3pKvq8mRA=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "49ff0692b00466bee56c3c72e91e4d0b8342a93b",
+        "rev": "0990740d36eb5674abfd899746ac5f51a96bf1c0",
         "type": "github"
       },
       "original": {
@@ -632,11 +632,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1773431856,
-        "narHash": "sha256-Oj4HMwF261bJCS/zqgmqdxoCBSeEjwghxW+1MA9Ktik=",
+        "lastModified": 1773532807,
+        "narHash": "sha256-02OCZKwq7JsocizEcvJVt1uMkQzWT6abPemKQU3y1U8=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "fd1e019e90e76bb3f6236210ac6287f3b8d4d47f",
+        "rev": "9084483715649194de0497310ae191e35dab8e26",
         "type": "github"
       },
       "original": {
@@ -715,11 +715,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1773282481,
-        "narHash": "sha256-b/GV2ysM8mKHhinse2wz+uP37epUrSE+sAKXy/xvBY4=",
+        "lastModified": 1773389992,
+        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fe416aaedd397cacb33a610b33d60ff2b431b127",
+        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
         "type": "github"
       },
       "original": {
@@ -741,11 +741,11 @@
         "systems": "systems_8"
       },
       "locked": {
-        "lastModified": 1773343795,
-        "narHash": "sha256-0+HEuOytpwyPt7i1jj6v2QJ+NXXisCYnL2XNwPBltvg=",
+        "lastModified": 1773579076,
+        "narHash": "sha256-GRuK5zh0Z68YXIoTpHQW2CFdpZRhGJRxpYh4vPOqjt4=",
         "owner": "NotAShelf",
         "repo": "nvf",
-        "rev": "83b44eaf50b96bd5d06b1a56a3a51f1b2362db52",
+        "rev": "baf207654ca613173e9d4b5255dba52f8c0c5577",
         "type": "github"
       },
       "original": {
@@ -830,11 +830,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773457417,
-        "narHash": "sha256-waABTSxPdbxml4BhcabHhyQF02Qnj27qRU4ard0mTQo=",
+        "lastModified": 1773544328,
+        "narHash": "sha256-Iv+qez54LAz+isij4APBk31VWA//Go81hwFOXr5iWTw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "055977c30249484010750e03074c744dcdaa0d23",
+        "rev": "4f977d776793c8bfbfdd7eca7835847ccc48874e",
         "type": "github"
       },
       "original": {
@@ -982,8 +982,8 @@
         "systems": "systems_10"
       },
       "locked": {
-        "lastModified": 1773468086,
-        "narHash": "sha256-73u+5t78rUZt8KeHuexW1MkWLHo8nLUHqQcvPtScNuw=",
+        "lastModified": 1773470471,
+        "narHash": "sha256-qTZ4SFcgBPSuzjvSZu4jXqodIyyIMkFRz4BHFJr+MFg=",
         "path": "/home/y0usaf/Dev/strictix",
         "type": "path"
       },

--- a/lib/appearance/wallust/templates/foot.nix
+++ b/lib/appearance/wallust/templates/foot.nix
@@ -1,6 +1,6 @@
 # Foot terminal colors (uses | strip to remove # from hex)
 ''
-  [colors]
+  [colors-dark]
   foreground={{foreground | strip}}
   background={{background | strip}}
   selection-foreground={{background | strip}}

--- a/lib/shell/nushell/common-aliases.nix
+++ b/lib/shell/nushell/common-aliases.nix
@@ -7,7 +7,7 @@ _: ''
   def lintfix [] { clear; ^statix fix .; ^deadnix . }
 
   # Wallust wrapper
-  alias wt = wallust
+  alias wallust = wt
 
   # Claude Code
   alias claude = claude --allow-dangerously-skip-permissions
@@ -21,6 +21,9 @@ _: ''
   alias ll = lsd -l --color=always --group-dirs=first --icon=always
   alias ls = lsd -lA --color=always --group-dirs=first --icon=always
   alias lt = lsd -A --tree --color=always --group-dirs=first --icon=always
+
+  # Directory listing
+  def dir [...args: string] { ^dir --color=auto ...$args }
 
   # Grep replacements with ripgrep
   def grep [...args: string] { ^rg --color auto ...$args }

--- a/lib/shell/nushell/common-aliases.nix
+++ b/lib/shell/nushell/common-aliases.nix
@@ -2,9 +2,9 @@
 # Nushell aliases cannot contain pipes or env var expansion at call time.
 # Complex aliases that need those features use `def` commands instead.
 _: ''
-  # Development tools
-  alias lintcheck = clear; statix check .; deadnix .
-  alias lintfix = clear; statix fix .; deadnix .
+  # Development tools (must be def - semicolons in aliases execute immediately)
+  def lintcheck [] { clear; ^statix check .; ^deadnix . }
+  def lintfix [] { clear; ^statix fix .; ^deadnix . }
 
   # Wallust wrapper
   alias wt = wallust

--- a/lib/shell/nushell/common-aliases.nix
+++ b/lib/shell/nushell/common-aliases.nix
@@ -1,0 +1,36 @@
+# Cross-platform aliases for Nushell
+# Nushell aliases cannot contain pipes or env var expansion at call time.
+# Complex aliases that need those features use `def` commands instead.
+_: ''
+  # Development tools
+  alias lintcheck = clear; statix check .; deadnix .
+  alias lintfix = clear; statix fix .; deadnix .
+
+  # Wallust wrapper
+  alias wt = wallust
+
+  # Claude Code
+  alias claude = claude --allow-dangerously-skip-permissions
+
+  # AI CLI tools via bunx
+  alias buncodex = bunx --bun @openai/codex
+  alias gemini = bunx --bun @google/gemini-cli@preview
+
+  # File listing with lsd
+  alias la = lsd -A --color=always --group-dirs=first --icon=always
+  alias ll = lsd -l --color=always --group-dirs=first --icon=always
+  alias ls = lsd -lA --color=always --group-dirs=first --icon=always
+  alias lt = lsd -A --tree --color=always --group-dirs=first --icon=always
+
+  # Grep replacements with ripgrep
+  def grep [...args: string] { ^rg --color auto ...$args }
+  def egrep [...args: string] { ^rg --color auto ...$args }
+  def fgrep [...args: string] { ^rg -F --color auto ...$args }
+
+  # Hidden files listing (uses pipe - must be def)
+  def "l." [] { ^lsd -A | lines | where $it =~ '^\.' }
+
+  # XDG compliance (uses env var expansion - must be def)
+  def wget [...args: string] { ^wget $"--hsts-file=($env.XDG_DATA_HOME)/wget-hsts" ...$args }
+  def svn [...args: string] { ^svn --config-dir $"($env.XDG_CONFIG_HOME)/subversion" ...$args }
+''

--- a/lib/shell/nushell/export-vars.nix
+++ b/lib/shell/nushell/export-vars.nix
@@ -1,0 +1,16 @@
+{config}: ''
+  def export_vars_from_files [dir_path: string] {
+    if not ($dir_path | path exists) { return }
+    let skip_keys = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
+    for file in (ls $dir_path | where type == file | get name) {
+      let var_name = ($file | path basename | str replace '.txt' '''')
+      if not ($var_name =~ '^[a-zA-Z_][a-zA-Z0-9_]*$') { continue }
+      if ($var_name in $skip_keys) { continue }
+      let content = (open $file | str trim)
+      if ($content | is-empty) { continue }
+      if ($content =~ '-----') { continue }
+      load-env {($var_name): $content}
+    }
+  }
+  export_vars_from_files "${config.user.homeDirectory}/Tokens"
+''

--- a/lib/shell/nushell/export-vars.nix
+++ b/lib/shell/nushell/export-vars.nix
@@ -3,7 +3,7 @@
     if not ($dir_path | path exists) { return }
     let skip_keys = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY"]
     for file in (ls $dir_path | where type == file | get name) {
-      let var_name = ($file | path basename | str replace '.txt' '''')
+      let var_name = ($file | path basename | str replace '.txt' "")
       if not ($var_name =~ '^[a-zA-Z_][a-zA-Z0-9_]*$') { continue }
       if ($var_name in $skip_keys) { continue }
       let content = (open $file | str trim)

--- a/lib/shell/nushell/functions.nix
+++ b/lib/shell/nushell/functions.nix
@@ -1,0 +1,13 @@
+_: {
+  temppkg = ''
+    def temppkg [package: string] {
+      ^nix-shell -p $package --run $"exec ($env.SHELL)"
+    }
+  '';
+
+  temprun = ''
+    def temprun [package: string, ...args: string] {
+      ^nix run $"nixpkgs#($package)" -- ...$args
+    }
+  '';
+}

--- a/lib/shell/nushell/nixos-aliases.nix
+++ b/lib/shell/nushell/nixos-aliases.nix
@@ -11,10 +11,10 @@ _: ''
 
   # Nix store queries (uses pipes - must be def)
   def pkgs [query: string] {
-    ^nix-store --query --requisites /run/current-system | lines | each { |l| $l | str replace -r '^[^-]*-' '''' } | sort | uniq | where $it =~ $query
+    ^nix-store --query --requisites /run/current-system | lines | each { |l| $l | str replace -r '^[^-]*-' "" } | sort | uniq | where $it =~ $query
   }
 
   def pkgcount [] {
-    ^nix-store --query --requisites /run/current-system | lines | each { |l| $l | str replace -r '^[^-]*-' '''' } | sort | uniq | length
+    ^nix-store --query --requisites /run/current-system | lines | each { |l| $l | str replace -r '^[^-]*-' "" } | sort | uniq | length
   }
 ''

--- a/lib/shell/nushell/nixos-aliases.nix
+++ b/lib/shell/nushell/nixos-aliases.nix
@@ -1,0 +1,20 @@
+# NixOS-specific aliases for Nushell
+_: ''
+  # Android development (env var override - must be def)
+  def adb [...args: string] { with-env { HOME: $"($env.XDG_DATA_HOME)/android" } { ^adb ...$args } }
+
+  # Music on console
+  def mocp [...args: string] { ^mocp -M $"($env.XDG_CONFIG_HOME)/moc" -O $"MOCDir=($env.XDG_CONFIG_HOME)/moc" ...$args }
+
+  # Yarn XDG compliance
+  def yarn [...args: string] { ^yarn --use-yarnrc $"($env.XDG_CONFIG_HOME)/yarn/config" ...$args }
+
+  # Nix store queries (uses pipes - must be def)
+  def pkgs [query: string] {
+    ^nix-store --query --requisites /run/current-system | lines | each { |l| $l | str replace -r '^[^-]*-' '''' } | sort | uniq | where $it =~ $query
+  }
+
+  def pkgcount [] {
+    ^nix-store --query --requisites /run/current-system | lines | each { |l| $l | str replace -r '^[^-]*-' '''' } | sort | uniq | length
+  }
+''

--- a/nixos/user/dev/claude-code/default.nix
+++ b/nixos/user/dev/claude-code/default.nix
@@ -78,7 +78,6 @@ in {
           "todowrite-instruct@y0usaf-marketplace" = false;
           "tool-tracker@y0usaf-marketplace" = false;
           "ralph-loop@claude-plugins-official" = false;
-          "code-simplifier@claude-plugins-official" = true;
           "codex-mcp@ai-eng-plugins" = false;
           "collab-flow@ai-eng-plugins" = false;
           "skills-framework@ai-eng-plugins" = true;

--- a/nixos/user/dev/python.nix
+++ b/nixos/user/dev/python.nix
@@ -25,65 +25,124 @@
       pkgs.gcc
       pkgs.binutils
     ];
-    usr.files = lib.optionalAttrs config.user.shell.zsh.enable {
-      ".config/zsh/.zshenv" = {
-        clobber = true;
-        text = lib.mkAfter ''
-          export PYTHONUSERBASE="${config.user.homeDirectory}/.local/share/python"
-          export PIP_CACHE_DIR="${config.user.homeDirectory}/.cache/pip"
-          export VIRTUAL_ENV_HOME="${config.user.homeDirectory}/.local/share/venvs"
-          export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-          export REQUESTS_CA_BUNDLE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
-          export NIX_LD_LIBRARY_PATH="${lib.makeLibraryPath [
-            pkgs.stdenv.cc.cc.lib
-            pkgs.zlib
-            pkgs.libGL
-            pkgs.glib
-            pkgs.libx11
-            pkgs.libxext
-            pkgs.libxrender
-          ]}"
-          export NIX_LD="${pkgs.stdenv.cc.bintools.dynamicLinker}"
-          export CC="${pkgs.gcc}/bin/gcc"
-          export LD="${pkgs.binutils}/bin/ld"
-          export PATH="$PYTHONUSERBASE/bin:$PATH"
-        '';
-      };
-      ".config/zsh/.zshrc" = {
-        clobber = true;
-        text = lib.mkAfter ''
-          alias py="python3"
-          alias pip="pip3"
-          alias venv="python3 -m venv"
-          alias activate="source venv/bin/activate"
-          alias uv-init="uv init"
-          alias uv-add="uv add"
-          alias uv-run="uv run"
-          mkvenv() {
-            if [[ -z "$1" ]]; then
-              python3 -m venv venv
-            else
-              python3 -m venv "$1"
-            fi
-          }
-          workon() {
-            if [[ -z "$1" ]]; then
-              if [[ -d "venv" ]]; then
-                source venv/bin/activate
+    usr.files = let
+      ldLibPath = lib.makeLibraryPath [
+        pkgs.stdenv.cc.cc.lib
+        pkgs.zlib
+        pkgs.libGL
+        pkgs.glib
+        pkgs.libx11
+        pkgs.libxext
+        pkgs.libxrender
+      ];
+    in
+      lib.optionalAttrs config.user.shell.zsh.enable {
+        ".config/zsh/.zshenv" = {
+          clobber = true;
+          text = lib.mkAfter ''
+            export PYTHONUSERBASE="${config.user.homeDirectory}/.local/share/python"
+            export PIP_CACHE_DIR="${config.user.homeDirectory}/.cache/pip"
+            export VIRTUAL_ENV_HOME="${config.user.homeDirectory}/.local/share/venvs"
+            export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            export REQUESTS_CA_BUNDLE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            export NIX_LD_LIBRARY_PATH="${ldLibPath}"
+            export NIX_LD="${pkgs.stdenv.cc.bintools.dynamicLinker}"
+            export CC="${pkgs.gcc}/bin/gcc"
+            export LD="${pkgs.binutils}/bin/ld"
+            export PATH="$PYTHONUSERBASE/bin:$PATH"
+          '';
+        };
+        ".config/zsh/.zshrc" = {
+          clobber = true;
+          text = lib.mkAfter ''
+            alias py="python3"
+            alias pip="pip3"
+            alias venv="python3 -m venv"
+            alias activate="source venv/bin/activate"
+            alias uv-init="uv init"
+            alias uv-add="uv add"
+            alias uv-run="uv run"
+            mkvenv() {
+              if [[ -z "$1" ]]; then
+                python3 -m venv venv
               else
-                echo "No venv directory found"
+                python3 -m venv "$1"
               fi
-            else
-              if [[ -d "$VIRTUAL_ENV_HOME/$1" ]]; then
-                source "$VIRTUAL_ENV_HOME/$1/bin/activate"
+            }
+            workon() {
+              if [[ -z "$1" ]]; then
+                if [[ -d "venv" ]]; then
+                  source venv/bin/activate
+                else
+                  echo "No venv directory found"
+                fi
               else
-                echo "Virtual environment $1 not found"
+                if [[ -d "$VIRTUAL_ENV_HOME/$1" ]]; then
+                  source "$VIRTUAL_ENV_HOME/$1/bin/activate"
+                else
+                  echo "Virtual environment $1 not found"
+                fi
               fi
-            fi
-          }
-        '';
+            }
+          '';
+        };
+      }
+      // lib.optionalAttrs config.user.shell.nushell.enable {
+        ".config/nushell/env.nu" = {
+          clobber = true;
+          text = lib.mkAfter ''
+            $env.PYTHONUSERBASE = "${config.user.homeDirectory}/.local/share/python"
+            $env.PIP_CACHE_DIR = "${config.user.homeDirectory}/.cache/pip"
+            $env.VIRTUAL_ENV_HOME = "${config.user.homeDirectory}/.local/share/venvs"
+            $env.SSL_CERT_FILE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            $env.REQUESTS_CA_BUNDLE = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            $env.NIX_LD_LIBRARY_PATH = "${ldLibPath}"
+            $env.NIX_LD = "${pkgs.stdenv.cc.bintools.dynamicLinker}"
+            $env.CC = "${pkgs.gcc}/bin/gcc"
+            $env.LD = "${pkgs.binutils}/bin/ld"
+            $env.PATH = ($env.PATH | prepend $"($env.PYTHONUSERBASE)/bin")
+          '';
+        };
+        ".config/nushell/config.nu" = {
+          clobber = true;
+          text = lib.mkAfter ''
+            alias py = python3
+            alias pip = pip3
+            alias uv-init = uv init
+            alias uv-add = uv add
+            alias uv-run = uv run
+            def mkvenv [name?: string] {
+              if ($name | is-empty) {
+                ^python3 -m venv venv
+              } else {
+                ^python3 -m venv $name
+              }
+            }
+            def workon [name?: string] {
+              if ($name | is-empty) {
+                if ("venv" | path exists) {
+                  load-env {
+                    VIRTUAL_ENV: $"(pwd)/venv"
+                    PATH: ($env.PATH | prepend $"(pwd)/venv/bin")
+                  }
+                } else {
+                  print "No venv directory found"
+                }
+              } else {
+                let venv_path = $"($env.VIRTUAL_ENV_HOME)/($name)"
+                if ($venv_path | path exists) {
+                  load-env {
+                    VIRTUAL_ENV: $venv_path
+                    PATH: ($env.PATH | prepend $"($venv_path)/bin")
+                  }
+                } else {
+                  print $"Virtual environment ($name) not found"
+                }
+              }
+            }
+          '';
+        };
       };
-    };
     systemd.tmpfiles.rules = [
       "d ${config.user.homeDirectory}/.local/share/python 0755 ${config.user.name} ${config.user.name} - -"
       "d ${config.user.homeDirectory}/.cache/pip 0755 ${config.user.name} ${config.user.name} - -"

--- a/nixos/user/dev/upscale.nix
+++ b/nixos/user/dev/upscale.nix
@@ -12,13 +12,22 @@
     environment.systemPackages = [
       pkgs.realesrgan-ncnn-vulkan
     ];
-    usr.files = lib.optionalAttrs config.user.shell.zsh.enable {
-      ".config/zsh/aliases/esrgan.zsh" = {
-        text = ''
-          alias esrgan="realesrgan-ncnn-vulkan -i ${config.user.homeDirectory}/Pictures/Upscale/Input -o ${config.user.homeDirectory}/Pictures/Upscale/Output"
-        '';
-        clobber = true;
+    usr.files =
+      lib.optionalAttrs config.user.shell.zsh.enable {
+        ".config/zsh/aliases/esrgan.zsh" = {
+          text = ''
+            alias esrgan="realesrgan-ncnn-vulkan -i ${config.user.homeDirectory}/Pictures/Upscale/Input -o ${config.user.homeDirectory}/Pictures/Upscale/Output"
+          '';
+          clobber = true;
+        };
+      }
+      // lib.optionalAttrs config.user.shell.nushell.enable {
+        ".config/nushell/config.nu" = {
+          text = lib.mkAfter ''
+            alias esrgan = realesrgan-ncnn-vulkan -i ${config.user.homeDirectory}/Pictures/Upscale/Input -o ${config.user.homeDirectory}/Pictures/Upscale/Output
+          '';
+          clobber = true;
+        };
       };
-    };
   };
 }

--- a/nixos/user/programs/browsers/firefox.nix
+++ b/nixos/user/programs/browsers/firefox.nix
@@ -53,6 +53,15 @@ in {
             '';
             clobber = true;
           };
+        }
+        // lib.optionalAttrs user.shell.nushell.enable {
+          ".config/nushell/login.nu" = {
+            text = lib.mkAfter ''
+              $env.MOZ_ENABLE_WAYLAND = "1"
+              $env.MOZ_USE_XINPUT2 = "1"
+            '';
+            clobber = true;
+          };
         };
     };
   };

--- a/nixos/user/programs/browsers/librewolf.nix
+++ b/nixos/user/programs/browsers/librewolf.nix
@@ -60,6 +60,15 @@ in {
             '';
             clobber = true;
           };
+        }
+        // lib.optionalAttrs user.shell.nushell.enable {
+          ".config/nushell/login.nu" = {
+            text = lib.mkAfter ''
+              $env.MOZ_ENABLE_WAYLAND = "1"
+              $env.MOZ_USE_XINPUT2 = "1"
+            '';
+            clobber = true;
+          };
         };
     };
   };

--- a/nixos/user/services/ssh.nix
+++ b/nixos/user/services/ssh.nix
@@ -57,6 +57,14 @@
             export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent"
           '';
         };
+      }
+      // lib.optionalAttrs config.user.shell.nushell.enable {
+        ".config/nushell/env.nu" = {
+          clobber = true;
+          text = lib.mkAfter ''
+            $env.SSH_AUTH_SOCK = $"($env.XDG_RUNTIME_DIR? | default '/run/user/1000')/ssh-agent"
+          '';
+        };
       };
     systemd.user.services.ssh-agent = {
       description = "SSH key agent";

--- a/nixos/user/shell/cat-fetch.nix
+++ b/nixos/user/shell/cat-fetch.nix
@@ -57,30 +57,21 @@
         ".config/nushell/cat-fetch.nu" = {
           text = ''
             def print_cats [] {
-              let colors_file = $"($env.HOME)/.cache/wallust/shell-colors.sh"
-              mut tomoe = (ansi magenta)
-              mut moon = (ansi green)
-              mut ekko = (ansi cyan)
-              mut bozo = (ansi red)
+              # Use terminal palette colors (indices 0-15 controlled by Wallust)
+              let e = $"\u{1b}"
+              let tomoe = $"($e)[38;5;13m"  # Magenta
+              let moon = $"($e)[38;5;2m"    # Green
+              let ekko = $"($e)[38;5;12m"   # Cyan
+              let bozo = $"($e)[38;5;9m"    # Bright red
+              let r = (ansi reset)
 
-              if ($colors_file | path exists) {
-                # Parse wallust shell colors
-                let colors = (open $colors_file | lines | where $it =~ '=' | each { |line|
-                  let parts = ($line | str replace "export " "" | split column "=" name value)
-                  {name: ($parts | get name.0), value: ($parts | get value.0 | str replace -a "'" "" | str replace -a '"' '''')}
-                } | reduce -f {} { |it, acc| $acc | merge {($it.name): $it.value} })
-                $tomoe = ($colors | get -i WALLUST_COLOR13 | default (ansi magenta))
-                $moon = ($colors | get -i WALLUST_COLOR2 | default (ansi green))
-                $ekko = ($colors | get -i WALLUST_COLOR12 | default (ansi cyan))
-                $bozo = ($colors | get -i WALLUST_COLOR9 | default (ansi red))
-              }
+              let line1 = $"($tomoe) ⟋|､      ($moon)  ⟋|､      ($ekko)  ⟋|､      ($bozo)  ⟋|､"
+              let line2 = [$tomoe "(°､ ｡ 7    " $moon "(°､ ｡ 7    " $ekko "(°､ ｡ 7    " $bozo "(°､ ｡ 7"] | str join
+              let line3 = $"($tomoe) |､  ~ヽ   ($moon) |､  ~ヽ   ($ekko) |､  ~ヽ   ($bozo) |､  ~ヽ"
+              let line4 = [$tomoe " じしf_,)〳" $moon " じしf_,)〳" $ekko " じしf_,)〳" $bozo " じしf_,)〳"] | str join
+              let line5 = $"($bozo)  [tomo]   ($tomoe)  [moon]   ($moon)  [ekko]   ($ekko)  [bozo]($r)"
 
-              let reset = (ansi reset)
-              print $"($tomoe) ⟋|､      ($moon)  ⟋|､      ($ekko)  ⟋|､      ($bozo)  ⟋|､
-            ($tomoe)\(°､ ｡ 7    ($moon)\(°､ ｡ 7    ($ekko)\(°､ ｡ 7    ($bozo)\(°､ ｡ 7
-            ($tomoe) |､  ~ヽ   ($moon) |､  ~ヽ   ($ekko) |､  ~ヽ   ($bozo) |､  ~ヽ
-            ($tomoe) じしf_,)〳($moon) じしf_,)〳($ekko) じしf_,)〳($bozo) じしf_,)〳
-            ($bozo)  [tomo]   ($tomoe)  [moon]   ($moon)  [ekko]   ($ekko)  [bozo]($reset)"
+              print ([$line1 $line2 $line3 $line4 $line5] | str join "\n")
             }
 
             print_cats

--- a/nixos/user/shell/cat-fetch.nix
+++ b/nixos/user/shell/cat-fetch.nix
@@ -7,44 +7,86 @@
     enable = lib.mkEnableOption "cat fetch display on shell startup";
   };
   config = lib.mkIf config.user.shell.cat-fetch.enable {
-    usr.files = lib.optionalAttrs config.user.shell.zsh.enable {
-      ".config/zsh/.zshrc" = {
-        text = lib.mkAfter ''
-          source "$ZDOTDIR/cat-fetch.zsh"
-        '';
-        clobber = true;
+    usr.files =
+      lib.optionalAttrs config.user.shell.zsh.enable {
+        ".config/zsh/.zshrc" = {
+          text = lib.mkAfter ''
+            source "$ZDOTDIR/cat-fetch.zsh"
+          '';
+          clobber = true;
+        };
+        ".config/zsh/cat-fetch.zsh" = {
+          text = ''
+            print_cats() {
+              # Source Wallust terminal colors (palette references that update dynamically)
+              if [ -f "$HOME/.cache/wallust/shell-colors.sh" ]; then
+                source "$HOME/.cache/wallust/shell-colors.sh"
+                local tomoe_colour="$WALLUST_COLOR13"  # Magenta
+                local moon_colour="$WALLUST_COLOR2"   # Green
+                local ekko_colour="$WALLUST_COLOR12"  # Cyan
+                local bozo_colour="$WALLUST_COLOR9"   # Bright red
+              else
+                # Fallback: use basic ANSI colors if Wallust not initialized
+                local tomoe_colour='\033[38;5;13m'    # Bright magenta
+                local moon_colour='\033[38;5;2m'     # Green
+                local ekko_colour='\033[38;5;12m'    # Bright cyan
+                local bozo_colour='\033[38;5;9m'     # Bright red
+              fi
+
+              local reset='\033[0m'
+
+              echo -e "''${tomoe_colour} ⟋|､      ''${moon_colour}  ⟋|､      ''${ekko_colour}  ⟋|､      ''${bozo_colour}  ⟋|､
+            ''${tomoe_colour}(°､ ｡ 7    ''${moon_colour}(°､ ｡ 7    ''${ekko_colour}(°､ ｡ 7    ''${bozo_colour}(°､ ｡ 7
+            ''${tomoe_colour} |､  ~ヽ   ''${moon_colour} |､  ~ヽ   ''${ekko_colour} |､  ~ヽ   ''${bozo_colour} |､  ~ヽ
+            ''${tomoe_colour} じしf_,)〳''${moon_colour} じしf_,)〳''${ekko_colour} じしf_,)〳''${bozo_colour} じしf_,)〳
+            ''${bozo_colour}  [tomo]   ''${tomoe_colour}  [moon]   ''${moon_colour}  [ekko]   ''${ekko_colour}  [bozo]''${reset}"
+            }
+
+            print_cats
+          '';
+          clobber = true;
+        };
+      }
+      // lib.optionalAttrs config.user.shell.nushell.enable {
+        ".config/nushell/config.nu" = {
+          text = lib.mkAfter ''
+            source ~/.config/nushell/cat-fetch.nu
+          '';
+          clobber = true;
+        };
+        ".config/nushell/cat-fetch.nu" = {
+          text = ''
+            def print_cats [] {
+              let colors_file = $"($env.HOME)/.cache/wallust/shell-colors.sh"
+              mut tomoe = (ansi magenta)
+              mut moon = (ansi green)
+              mut ekko = (ansi cyan)
+              mut bozo = (ansi red)
+
+              if ($colors_file | path exists) {
+                # Parse wallust shell colors
+                let colors = (open $colors_file | lines | where $it =~ '=' | each { |line|
+                  let parts = ($line | str replace "export " "" | split column "=" name value)
+                  {name: ($parts | get name.0), value: ($parts | get value.0 | str replace -a "'" "" | str replace -a '"' '''')}
+                } | reduce -f {} { |it, acc| $acc | merge {($it.name): $it.value} })
+                $tomoe = ($colors | get -i WALLUST_COLOR13 | default (ansi magenta))
+                $moon = ($colors | get -i WALLUST_COLOR2 | default (ansi green))
+                $ekko = ($colors | get -i WALLUST_COLOR12 | default (ansi cyan))
+                $bozo = ($colors | get -i WALLUST_COLOR9 | default (ansi red))
+              }
+
+              let reset = (ansi reset)
+              print $"($tomoe) ⟋|､      ($moon)  ⟋|､      ($ekko)  ⟋|､      ($bozo)  ⟋|､
+            ($tomoe)\(°､ ｡ 7    ($moon)\(°､ ｡ 7    ($ekko)\(°､ ｡ 7    ($bozo)\(°､ ｡ 7
+            ($tomoe) |､  ~ヽ   ($moon) |､  ~ヽ   ($ekko) |､  ~ヽ   ($bozo) |､  ~ヽ
+            ($tomoe) じしf_,)〳($moon) じしf_,)〳($ekko) じしf_,)〳($bozo) じしf_,)〳
+            ($bozo)  [tomo]   ($tomoe)  [moon]   ($moon)  [ekko]   ($ekko)  [bozo]($reset)"
+            }
+
+            print_cats
+          '';
+          clobber = true;
+        };
       };
-      ".config/zsh/cat-fetch.zsh" = {
-        text = ''
-          print_cats() {
-            # Source Wallust terminal colors (palette references that update dynamically)
-            if [ -f "$HOME/.cache/wallust/shell-colors.sh" ]; then
-              source "$HOME/.cache/wallust/shell-colors.sh"
-              local tomoe_colour="$WALLUST_COLOR13"  # Magenta
-              local moon_colour="$WALLUST_COLOR2"   # Green
-              local ekko_colour="$WALLUST_COLOR12"  # Cyan
-              local bozo_colour="$WALLUST_COLOR9"   # Bright red
-            else
-              # Fallback: use basic ANSI colors if Wallust not initialized
-              local tomoe_colour='\033[38;5;13m'    # Bright magenta
-              local moon_colour='\033[38;5;2m'     # Green
-              local ekko_colour='\033[38;5;12m'    # Bright cyan
-              local bozo_colour='\033[38;5;9m'     # Bright red
-            fi
-
-            local reset='\033[0m'
-
-            echo -e "''${tomoe_colour} ⟋|､      ''${moon_colour}  ⟋|､      ''${ekko_colour}  ⟋|､      ''${bozo_colour}  ⟋|､
-          ''${tomoe_colour}(°､ ｡ 7    ''${moon_colour}(°､ ｡ 7    ''${ekko_colour}(°､ ｡ 7    ''${bozo_colour}(°､ ｡ 7
-          ''${tomoe_colour} |､  ~ヽ   ''${moon_colour} |､  ~ヽ   ''${ekko_colour} |､  ~ヽ   ''${bozo_colour} |､  ~ヽ
-          ''${tomoe_colour} じしf_,)〳''${moon_colour} じしf_,)〳''${ekko_colour} じしf_,)〳''${bozo_colour} じしf_,)〳
-          ''${bozo_colour}  [tomo]   ''${tomoe_colour}  [moon]   ''${moon_colour}  [ekko]   ''${ekko_colour}  [bozo]''${reset}"
-          }
-
-          print_cats
-        '';
-        clobber = true;
-      };
-    };
   };
 }

--- a/nixos/user/shell/default.nix
+++ b/nixos/user/shell/default.nix
@@ -3,5 +3,6 @@ _: {
     ./cat-fetch.nix
     ./zellij
     ./zsh
+    ./nushell
   ];
 }

--- a/nixos/user/shell/nushell/aliases.nix
+++ b/nixos/user/shell/nushell/aliases.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  config,
+  flakeDirectory,
+}:
+(import ../../../../lib/shell/nushell/common-aliases.nix {})
++ (import ../../../../lib/shell/nushell/nixos-aliases.nix {})
++ ''
+
+  # NixOS build timing
+  def buildtime [] { timeit { ^nix build $"($env.NH_FLAKE)#nixosConfigurations.($env.HOST).config.system.build.toplevel" --option eval-cache false } }
+
+  # Git helpers for flake repo
+  def hmpush [] { ^git -C ${flakeDirectory} push origin main --force }
+  def hmpull [] { ^git -C ${flakeDirectory} fetch origin; ^git -C ${flakeDirectory} reset --hard origin/main }
+''
++ lib.optionalString config.hardware.nvidia.enable ''
+
+  # Nvidia
+  def nvidia-settings [...args: string] { ^nvidia-settings $"--config=($env.XDG_CONFIG_HOME)/nvidia/settings" ...$args }
+  def gpupower [watts: string] { sudo nvidia-smi -pl $watts }
+''

--- a/nixos/user/shell/nushell/config.nix
+++ b/nixos/user/shell/nushell/config.nix
@@ -59,6 +59,13 @@
             text = "";
             clobber = true;
           };
+          ".config/nushell/carapace.nu" = {
+            source = pkgs.runCommand "carapace-init-nu" {} ''
+              export HOME=$(mktemp -d)
+              ${pkgs.carapace}/bin/carapace _carapace nushell > $out
+            '';
+            clobber = true;
+          };
         }
         // lib.optionalAttrs config.user.shell.zellij.enable {
           ".config/nushell/zellij.nu" = {

--- a/nixos/user/shell/nushell/config.nix
+++ b/nixos/user/shell/nushell/config.nix
@@ -31,6 +31,7 @@
             in
               lib.concatStringsSep "\n" (
                 [
+                  settings.banner
                   settings.history
                   settings.completion
                   settings.keybindings
@@ -62,7 +63,7 @@
           ".config/nushell/carapace.nu" = {
             source = pkgs.runCommand "carapace-init-nu" {} ''
               export HOME=$(mktemp -d)
-              ${pkgs.carapace}/bin/carapace _carapace nushell > $out
+              ${pkgs.carapace}/bin/carapace _carapace nushell | ${pkgs.gnused}/bin/sed '/\/build\/.*carapace\/bin/d' > $out
             '';
             clobber = true;
           };

--- a/nixos/user/shell/nushell/config.nix
+++ b/nixos/user/shell/nushell/config.nix
@@ -1,0 +1,90 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}: {
+  options.user.shell.nushell = {
+    enable = lib.mkEnableOption "nushell shell configuration";
+  };
+  config = lib.mkIf config.user.shell.nushell.enable {
+    environment.systemPackages = [
+      pkgs.nushell
+      pkgs.carapace
+      pkgs.bat
+      pkgs.lsd
+      pkgs.tree
+    ];
+
+    hjem.users."${config.user.name}" = {
+      files =
+        {
+          ".config/nushell/config.nu" = {
+            text = let
+              settings = import ./settings.nix {inherit config;};
+              libFunctions = import ../../../../lib/shell/nushell/functions.nix {};
+              aliases = import ./aliases.nix {
+                inherit lib config;
+                flakeDirectory = config.user.paths.flake.path;
+              };
+              localFunctions = import ./functions.nix {inherit config;};
+            in
+              lib.concatStringsSep "\n" (
+                [
+                  settings.history
+                  settings.completion
+                  settings.keybindings
+                  settings.carapace
+                  aliases
+                  libFunctions.temppkg
+                  libFunctions.temprun
+                  localFunctions
+                ]
+                ++ lib.optional config.user.shell.zellij.enable "source ~/.config/nushell/zellij.nu"
+              );
+            clobber = true;
+          };
+          ".config/nushell/env.nu" = {
+            text =
+              (import ../../../../lib/shell/nushell/export-vars.nix {inherit config;})
+              + ''
+
+                $env.TERMINAL = "${config.user.defaults.terminal}"
+                $env.BROWSER = "${config.user.defaults.browser}"
+                $env.EDITOR = "${config.user.defaults.editor}"
+              '';
+            clobber = true;
+          };
+          ".config/nushell/login.nu" = {
+            text = "";
+            clobber = true;
+          };
+        }
+        // lib.optionalAttrs config.user.shell.zellij.enable {
+          ".config/nushell/zellij.nu" = {
+            text = ''
+              # Skip if already in a multiplexer or SSH session
+              if ("ZELLIJ" in $env) or ("SSH_CONNECTION" in $env) or ("TMUX" in $env) { return }
+
+              # Skip if in virtual console
+              if ($env.TERM? | default "" ) == "linux" { return }
+
+              # Start Zellij
+              if ($env.ZELLIJ_AUTO_ATTACH? | default "false") == "true" {
+                exec zellij attach -c
+              } else {
+                exec zellij
+              }
+            '';
+            clobber = true;
+          };
+        };
+    };
+
+    # Set prompt in env.nu so it's available early
+    usr.files.".config/nushell/env.nu" = {
+      text = lib.mkAfter (import ./settings.nix {inherit config;}).prompt;
+      clobber = true;
+    };
+  };
+}

--- a/nixos/user/shell/nushell/default.nix
+++ b/nixos/user/shell/nushell/default.nix
@@ -1,0 +1,6 @@
+_: {
+  imports = [
+    ./config.nix
+    ./xdg-env.nix
+  ];
+}

--- a/nixos/user/shell/nushell/functions.nix
+++ b/nixos/user/shell/nushell/functions.nix
@@ -1,0 +1,9 @@
+{config}:
+if config.networking.hostName == "y0usaf-laptop"
+then ''
+  def fanspeed [percentage: string] {
+    ^asusctl fan-curve -m quiet -D $"30c:($percentage),40c:($percentage),50c:($percentage),60c:($percentage),70c:($percentage),80c:($percentage),90c:($percentage),100c:($percentage)" -e true -f gpu
+    ^asusctl fan-curve -m quiet -D $"30c:($percentage),40c:($percentage),50c:($percentage),60c:($percentage),70c:($percentage),80c:($percentage),90c:($percentage),100c:($percentage)" -e true -f cpu
+  }
+''
+else ""

--- a/nixos/user/shell/nushell/settings.nix
+++ b/nixos/user/shell/nushell/settings.nix
@@ -1,4 +1,8 @@
 _: {
+  banner = ''
+    $env.config.show_banner = false
+  '';
+
   history = ''
     $env.config.history = {
       max_size: 10000
@@ -37,7 +41,6 @@ _: {
   '';
 
   carapace = ''
-    $env.CARAPACE_BRIDGES = 'zsh,fish,bash,inshellisense'
     source ~/.config/nushell/carapace.nu
   '';
 

--- a/nixos/user/shell/nushell/settings.nix
+++ b/nixos/user/shell/nushell/settings.nix
@@ -1,4 +1,4 @@
-{config}: {
+_: {
   history = ''
     $env.config.history = {
       max_size: 10000
@@ -38,9 +38,7 @@
 
   carapace = ''
     $env.CARAPACE_BRIDGES = 'zsh,fish,bash,inshellisense'
-    mkdir ~/.cache/carapace
-    carapace _carapace nushell | save --force ~/.cache/carapace/init.nu
-    source ~/.cache/carapace/init.nu
+    source ~/.config/nushell/carapace.nu
   '';
 
   keybindings = ''

--- a/nixos/user/shell/nushell/settings.nix
+++ b/nixos/user/shell/nushell/settings.nix
@@ -1,0 +1,70 @@
+{config}: {
+  history = ''
+    $env.config.history = {
+      max_size: 10000
+      file_format: "sqlite"
+      sync_on_enter: true
+      isolation: false
+    }
+  '';
+
+  completion = ''
+    $env.config.completions = {
+      case_sensitive: false
+      quick: true
+      partial: true
+      algorithm: "fuzzy"
+      use_ls_colors: true
+    }
+  '';
+
+  prompt = ''
+    $env.PROMPT_COMMAND = {||
+      let path = ($env.PWD | str replace $env.HOME '~')
+      $"(ansi green_bold)($path)(ansi reset)"
+    }
+    $env.PROMPT_COMMAND_RIGHT = ""
+    $env.PROMPT_INDICATOR = {||
+      if ($env.LAST_EXIT_CODE == 0) {
+        $"(ansi cyan_bold)>(ansi reset) "
+      } else {
+        $"(ansi red_bold)>(ansi reset) "
+      }
+    }
+    $env.PROMPT_INDICATOR_VI_INSERT = "> "
+    $env.PROMPT_INDICATOR_VI_NORMAL = "〉"
+    $env.PROMPT_MULTILINE_INDICATOR = "::: "
+  '';
+
+  carapace = ''
+    $env.CARAPACE_BRIDGES = 'zsh,fish,bash,inshellisense'
+    mkdir ~/.cache/carapace
+    carapace _carapace nushell | save --force ~/.cache/carapace/init.nu
+    source ~/.cache/carapace/init.nu
+  '';
+
+  keybindings = ''
+    $env.config.keybindings = [
+      {
+        name: completion_menu
+        modifier: none
+        keycode: tab
+        mode: [emacs vi_normal vi_insert]
+        event: {
+          until: [
+            { send: menu name: completion_menu }
+            { send: menunext }
+            { edit: complete }
+          ]
+        }
+      }
+      {
+        name: history_menu
+        modifier: control
+        keycode: char_r
+        mode: [emacs vi_normal vi_insert]
+        event: { send: menu name: history_menu }
+      }
+    ]
+  '';
+}

--- a/nixos/user/shell/nushell/xdg-env.nix
+++ b/nixos/user/shell/nushell/xdg-env.nix
@@ -52,6 +52,13 @@
           $env.NPM_CONFIG_CACHE = $"($env.XDG_CACHE_HOME)/npm"
           $env.NPM_CONFIG_TMP = $"($env.XDG_RUNTIME_DIR? | default '/tmp')/npm"
           $env.NPM_CONFIG_INIT_MODULE = $"($env.XDG_CONFIG_HOME)/npm/config/npm-init.js"
+
+          # Ensure XDG directories exist
+          [$env.XDG_CONFIG_HOME $env.XDG_DATA_HOME $env.XDG_STATE_HOME $env.XDG_CACHE_HOME] | each { |d| mkdir $d }
+
+          # Ensure bun runtime dir exists
+          let runtime_dir = ($env.XDG_RUNTIME_DIR? | default null)
+          if $runtime_dir != null { mkdir $"($runtime_dir)/bun" }
         '';
       };
 

--- a/nixos/user/shell/nushell/xdg-env.nix
+++ b/nixos/user/shell/nushell/xdg-env.nix
@@ -1,0 +1,80 @@
+{
+  lib,
+  config,
+  ...
+}: {
+  config = lib.mkIf config.user.shell.nushell.enable {
+    usr.files = {
+      ".config/nushell/env.nu" = {
+        clobber = true;
+        text = ''
+          $env.XDG_CONFIG_HOME = $"($env.HOME)/.config"
+          $env.XDG_DATA_HOME = $"($env.HOME)/.local/share"
+          $env.XDG_STATE_HOME = $"($env.HOME)/.local/state"
+          $env.XDG_CACHE_HOME = $"($env.HOME)/.cache"
+
+          $env.XDG_SCREENSHOTS_DIR = $"($env.HOME)/Pictures/Screenshots"
+          $env.XDG_WALLPAPERS_DIR = $"($env.HOME)/Pictures/Wallpapers"
+
+          $env.ANDROID_HOME = $"($env.XDG_DATA_HOME)/android"
+          $env.ADB_VENDOR_KEY = $"($env.XDG_CONFIG_HOME)/android"
+          $env.PYENV_ROOT = $"($env.XDG_DATA_HOME)/pyenv"
+          $env.BUN_INSTALL = $"($env.XDG_DATA_HOME)/bun"
+          $env.BUNFIG = $"($env.XDG_CONFIG_HOME)/bun/bunfig.toml"
+          $env.NUGET_PACKAGES = $"($env.XDG_CACHE_HOME)/NuGetPackages"
+          $env.KERAS_HOME = $"($env.XDG_STATE_HOME)/keras"
+          $env.NIMBLE_DIR = $"($env.XDG_DATA_HOME)/nimble"
+          $env.DOTNET_CLI_HOME = $"($env.XDG_DATA_HOME)/dotnet"
+          $env.AWS_SHARED_CREDENTIALS_FILE = $"($env.XDG_CONFIG_HOME)/aws/credentials"
+          $env.CARGO_HOME = $"($env.XDG_DATA_HOME)/cargo"
+          $env.RUSTUP_HOME = $"($env.XDG_DATA_HOME)/rustup"
+          $env.GOPATH = $"($env.XDG_DATA_HOME)/go"
+          $env._JAVA_OPTIONS = $"-Djava.util.prefs.userRoot=\"($env.XDG_CONFIG_HOME)/java\""
+          $env.LESSHISTFILE = $"($env.XDG_STATE_HOME)/less/history"
+          $env.NODE_REPL_HISTORY = $"($env.XDG_STATE_HOME)/node_repl_history"
+          $env.PYTHONSTARTUP = $"($env.XDG_CONFIG_HOME)/python/pythonrc"
+          $env.SQLITE_HISTORY = $"($env.XDG_STATE_HOME)/sqlite_history"
+          $env.WGET_HSTS_FILE = $"($env.XDG_DATA_HOME)/wget-hsts"
+          $env.PYTHON_HISTORY = $"($env.XDG_STATE_HOME)/python_history"
+          $env.GNUPGHOME = $"($env.XDG_DATA_HOME)/gnupg"
+          $env.PARALLEL_HOME = $"($env.XDG_CONFIG_HOME)/parallel"
+
+          $env.DVDCSS_CACHE = $"($env.XDG_DATA_HOME)/dvdcss"
+          $env.WINEPREFIX = $"($env.XDG_DATA_HOME)/wine"
+          $env.TEXMFVAR = $"($env.XDG_CACHE_HOME)/texlive/texmf-var"
+          $env.SSB_HOME = $"($env.XDG_DATA_HOME)/zoom"
+          $env.__GL_SHADER_DISK_CACHE_PATH = $"($env.XDG_CACHE_HOME)/nv"
+          $env.DOCKER_CONFIG = $"($env.XDG_CONFIG_HOME)/docker"
+          $env.CUDA_CACHE_PATH = $"($env.XDG_CACHE_HOME)/nv"
+          $env.GRADLE_USER_HOME = $"($env.XDG_DATA_HOME)/gradle"
+          $env.GTK2_RC_FILES = $"($env.XDG_CONFIG_HOME)/gtk-2.0/gtkrc"
+          $env.NPM_CONFIG_USERCONFIG = $"($env.XDG_CONFIG_HOME)/npm/npmrc"
+          $env.NPM_CONFIG_CACHE = $"($env.XDG_CACHE_HOME)/npm"
+          $env.NPM_CONFIG_TMP = $"($env.XDG_RUNTIME_DIR? | default '/tmp')/npm"
+          $env.NPM_CONFIG_INIT_MODULE = $"($env.XDG_CONFIG_HOME)/npm/config/npm-init.js"
+        '';
+      };
+
+      ".config/python/pythonrc" = {
+        clobber = true;
+        text = ''
+          import os
+          import atexit
+          import readline
+          histfile = os.path.join(os.environ.get("XDG_STATE_HOME", os.path.expanduser("~/.local/state")), "python_history")
+          try:
+              readline.read_history_file(histfile)
+              h_len = readline.get_current_history_length()
+          except FileNotFoundError:
+              open(histfile, 'wb').close()
+              h_len = 0
+          def save(prev_h_len, histfile):
+              new_h_len = readline.get_current_history_length()
+              readline.set_history_length(1000)
+              readline.append_history_file(new_h_len - prev_h_len, histfile)
+          atexit.register(save, h_len, histfile)
+        '';
+      };
+    };
+  };
+}

--- a/nixos/user/shell/zellij/config.nix
+++ b/nixos/user/shell/zellij/config.nix
@@ -11,11 +11,26 @@
 
     # Wallust (core) manages zellij config files for dynamic theming
     # Only shell integration is managed here
-    usr.files = lib.optionalAttrs (config.user.shell.zellij.autoStart && config.user.shell.zsh.enable) {
-      ".config/zsh/zellij.zsh" = {
-        clobber = true;
-        text = (import ../../../../lib/shell/zellij/config.nix {inherit lib;}).shellIntegration;
+    usr.files =
+      lib.optionalAttrs (config.user.shell.zellij.autoStart && config.user.shell.zsh.enable) {
+        ".config/zsh/zellij.zsh" = {
+          clobber = true;
+          text = (import ../../../../lib/shell/zellij/config.nix {inherit lib;}).shellIntegration;
+        };
+      }
+      // lib.optionalAttrs (config.user.shell.zellij.autoStart && config.user.shell.nushell.enable) {
+        ".config/nushell/zellij.nu" = {
+          clobber = true;
+          text = ''
+            # Skip if already in a multiplexer or SSH session
+            if ("ZELLIJ" in $env) or ("SSH_CONNECTION" in $env) or ("TMUX" in $env) { return }
+
+            # Skip if in virtual console
+            if ($env.TERM? | default "") == "linux" { return }
+
+            exec zellij
+          '';
+        };
       };
-    };
   };
 }

--- a/nixos/user/tools/jj.nix
+++ b/nixos/user/tools/jj.nix
@@ -85,6 +85,26 @@
           '';
           clobber = true;
         };
+      }
+      // lib.optionalAttrs (config.user.tools.jj.enableAliases && config.user.shell.nushell.enable) {
+        ".config/nushell/config.nu" = {
+          text = lib.mkAfter ''
+            alias jl = jj log -r recent
+            alias jll = jj log -r ::@
+            alias js = jj status
+            alias jd = jj diff
+            alias jc = jj commit
+            alias jca = jj commit --amend
+            alias jco = jj checkout
+            alias jn = jj new
+            alias je = jj edit
+            alias jb = jj branch
+            alias jrb = jj rebase
+            alias jsp = jj split
+            alias jsq = jj squash
+          '';
+          clobber = true;
+        };
       };
   };
 }

--- a/nixos/user/tools/nh.nix
+++ b/nixos/user/tools/nh.nix
@@ -21,34 +21,62 @@
     environment.systemPackages = [
       pkgs.nh
     ];
-    usr.files.".config/zsh/.zshrc" = {
-      text = lib.mkAfter ''
-        export NH_FLAKE="${toString (
-          if config.user.tools.nh.flake != null
-          then config.user.tools.nh.flake
-          else config.user.paths.flake.path
-        )}"
-        nhs() {
-          clear
-          local update=""
-          local dry=""
-          local OPTIND
-          while getopts "du" opt; do
-            case $opt in
-              d) dry="--dry" ;;
-              u) update="--update" ;;
-              *) echo "Invalid option: -$OPTARG" >&2 ;;
-            esac
-          done
-          shift $((OPTIND-1))
-          nh os switch $update $dry "$@"
-        }
-        alias nhd="nhs -d"
-        alias nhu="nhs -u"
-        alias nhud="nhs -ud"
-        alias nhc="nh clean all"
-      '';
-      clobber = true;
-    };
+    usr.files = let
+      nhFlake = toString (
+        if config.user.tools.nh.flake != null
+        then config.user.tools.nh.flake
+        else config.user.paths.flake.path
+      );
+    in
+      {
+        ".config/zsh/.zshrc" = {
+          text = lib.mkAfter ''
+            export NH_FLAKE="${nhFlake}"
+            nhs() {
+              clear
+              local update=""
+              local dry=""
+              local OPTIND
+              while getopts "du" opt; do
+                case $opt in
+                  d) dry="--dry" ;;
+                  u) update="--update" ;;
+                  *) echo "Invalid option: -$OPTARG" >&2 ;;
+                esac
+              done
+              shift $((OPTIND-1))
+              nh os switch $update $dry "$@"
+            }
+            alias nhd="nhs -d"
+            alias nhu="nhs -u"
+            alias nhud="nhs -ud"
+            alias nhc="nh clean all"
+          '';
+          clobber = true;
+        };
+      }
+      // lib.optionalAttrs config.user.shell.nushell.enable {
+        ".config/nushell/env.nu" = {
+          text = lib.mkAfter ''
+            $env.NH_FLAKE = "${nhFlake}"
+          '';
+          clobber = true;
+        };
+        ".config/nushell/config.nu" = {
+          text = lib.mkAfter ''
+            def nhs [--dry(-d), --update(-u), ...rest: string] {
+              clear
+              let update_flag = if $update { ["--update"] } else { [] }
+              let dry_flag = if $dry { ["--dry"] } else { [] }
+              ^nh os switch ...$update_flag ...$dry_flag ...$rest
+            }
+            alias nhd = nhs -d
+            alias nhu = nhs -u
+            alias nhud = nhs -u -d
+            alias nhc = nh clean all
+          '';
+          clobber = true;
+        };
+      };
   };
 }

--- a/nixos/user/tools/yt-dlp.nix
+++ b/nixos/user/tools/yt-dlp.nix
@@ -13,19 +13,33 @@
       pkgs.ffmpeg
     ];
     usr = {
-      files = lib.optionalAttrs config.user.shell.zsh.enable {
-        ".config/zsh/.zshrc" = {
-          text = lib.mkAfter ''
-            alias ytm4a="yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -x --audio-format m4a --embed-metadata --add-metadata -o '%(title)s.%(ext)s'"
-            alias ytmp3="yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -x --audio-format mp3 --embed-metadata --add-metadata -o '%(title)s.%(ext)s'"
-            alias ytmp4="yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -f 'bv*[height<=720]+ba/b[height<=720]' --recode-video mp4 --embed-metadata --add-metadata --postprocessor-args 'ffmpeg:-c:v libx264 -crf 23 -preset medium -c:a aac -b:a 128k -vf scale=-2:720' -o '%(title)s.%(ext)s'"
-            alias ytmp4s="yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -f 'bv*[height<=480]+ba/b[height<=480]' --recode-video mp4 --embed-metadata --add-metadata --postprocessor-args 'ffmpeg:-c:v libx264 -crf 26 -preset faster -c:a aac -b:a 96k -vf scale=-2:480' -o '%(title)s.%(ext)s'"
-            alias ytwebm="yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -f 'bv*[height<=720]+ba/b[height<=720]' --recode-video webm --embed-metadata --add-metadata --postprocessor-args 'ffmpeg:-c:v libvpx-vp9 -crf 30 -b:v 0 -c:a libopus -vf scale=-2:720' -o '%(title)s.%(ext)s'"
-            alias ytdiscord="yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -f 'bv*[height<=720]+ba/b[height<=720]' --recode-video mp4 --embed-metadata --add-metadata --postprocessor-args 'ffmpeg:-c:v libx264 -crf 28 -preset faster -c:a aac -b:a 96k -vf scale=-2:min(720,ih) -fs 7.8M' -o '%(title)s_discord.%(ext)s'"
-          '';
-          clobber = true;
+      files =
+        lib.optionalAttrs config.user.shell.zsh.enable {
+          ".config/zsh/.zshrc" = {
+            text = lib.mkAfter ''
+              alias ytm4a="yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -x --audio-format m4a --embed-metadata --add-metadata -o '%(title)s.%(ext)s'"
+              alias ytmp3="yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -x --audio-format mp3 --embed-metadata --add-metadata -o '%(title)s.%(ext)s'"
+              alias ytmp4="yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -f 'bv*[height<=720]+ba/b[height<=720]' --recode-video mp4 --embed-metadata --add-metadata --postprocessor-args 'ffmpeg:-c:v libx264 -crf 23 -preset medium -c:a aac -b:a 128k -vf scale=-2:720' -o '%(title)s.%(ext)s'"
+              alias ytmp4s="yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -f 'bv*[height<=480]+ba/b[height<=480]' --recode-video mp4 --embed-metadata --add-metadata --postprocessor-args 'ffmpeg:-c:v libx264 -crf 26 -preset faster -c:a aac -b:a 96k -vf scale=-2:480' -o '%(title)s.%(ext)s'"
+              alias ytwebm="yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -f 'bv*[height<=720]+ba/b[height<=720]' --recode-video webm --embed-metadata --add-metadata --postprocessor-args 'ffmpeg:-c:v libvpx-vp9 -crf 30 -b:v 0 -c:a libopus -vf scale=-2:720' -o '%(title)s.%(ext)s'"
+              alias ytdiscord="yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -f 'bv*[height<=720]+ba/b[height<=720]' --recode-video mp4 --embed-metadata --add-metadata --postprocessor-args 'ffmpeg:-c:v libx264 -crf 28 -preset faster -c:a aac -b:a 96k -vf scale=-2:min(720,ih) -fs 7.8M' -o '%(title)s_discord.%(ext)s'"
+            '';
+            clobber = true;
+          };
+        }
+        // lib.optionalAttrs config.user.shell.nushell.enable {
+          ".config/nushell/config.nu" = {
+            text = lib.mkAfter ''
+              def ytm4a [...urls: string] { ^yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -x --audio-format m4a --embed-metadata --add-metadata -o '%(title)s.%(ext)s' ...$urls }
+              def ytmp3 [...urls: string] { ^yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -x --audio-format mp3 --embed-metadata --add-metadata -o '%(title)s.%(ext)s' ...$urls }
+              def ytmp4 [...urls: string] { ^yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -f 'bv*[height<=720]+ba/b[height<=720]' --recode-video mp4 --embed-metadata --add-metadata --postprocessor-args 'ffmpeg:-c:v libx264 -crf 23 -preset medium -c:a aac -b:a 128k -vf scale=-2:720' -o '%(title)s.%(ext)s' ...$urls }
+              def ytmp4s [...urls: string] { ^yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -f 'bv*[height<=480]+ba/b[height<=480]' --recode-video mp4 --embed-metadata --add-metadata --postprocessor-args 'ffmpeg:-c:v libx264 -crf 26 -preset faster -c:a aac -b:a 96k -vf scale=-2:480' -o '%(title)s.%(ext)s' ...$urls }
+              def ytwebm [...urls: string] { ^yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -f 'bv*[height<=720]+ba/b[height<=720]' --recode-video webm --embed-metadata --add-metadata --postprocessor-args 'ffmpeg:-c:v libvpx-vp9 -crf 30 -b:v 0 -c:a libopus -vf scale=-2:720' -o '%(title)s.%(ext)s' ...$urls }
+              def ytdiscord [...urls: string] { ^yt-dlp --extractor-args 'youtube:player_client=android' --no-check-certificate -f 'bv*[height<=720]+ba/b[height<=720]' --recode-video mp4 --embed-metadata --add-metadata --postprocessor-args 'ffmpeg:-c:v libx264 -crf 28 -preset faster -c:a aac -b:a 96k -vf scale=-2:min(720,ih) -fs 7.8M' -o '%(title)s_discord.%(ext)s' ...$urls }
+            '';
+            clobber = true;
+          };
         };
-      };
     };
   };
 }

--- a/nixos/user/ui/cursor.nix
+++ b/nixos/user/ui/cursor.nix
@@ -60,6 +60,19 @@ in {
               '');
             clobber = true;
           };
+        }
+        // lib.optionalAttrs user.shell.nushell.enable {
+          ".config/nushell/login.nu" = {
+            text = mkAfter (''
+                $env.XCURSOR_THEME = "${x11ThemeName}"
+                $env.XCURSOR_SIZE = "${toString cursorSize}"
+              ''
+              + lib.optionalString (hyprcursorPackage != null) ''
+                $env.HYPRCURSOR_THEME = "DeepinDarkV20-hypr"
+                $env.HYPRCURSOR_SIZE = "${toString cursorSize}"
+              '');
+            clobber = true;
+          };
         };
     };
   };

--- a/nixos/user/ui/foot.nix
+++ b/nixos/user/ui/foot.nix
@@ -41,7 +41,7 @@ in {
         hide-when-typing=no
         alternate-scroll-mode=yes
 
-        [colors]
+        [colors-dark]
         alpha=${toString userAppearance.opacity}
 
         [key-bindings]

--- a/nixos/user/ui/gtk/config.nix
+++ b/nixos/user/ui/gtk/config.nix
@@ -58,6 +58,15 @@
               export GDK_DPI_SCALE="${toString config.user.ui.gtk.scale}"
             '';
           };
+        }
+        // lib.optionalAttrs config.user.shell.nushell.enable {
+          ".config/nushell/env.nu" = {
+            clobber = true;
+            text = lib.mkAfter ''
+              $env.XCURSOR_SIZE = "${builtins.replaceStrings [".0"] [""] (toString (builtins.floor (24 * config.user.ui.gtk.scale)))}"
+              $env.GDK_DPI_SCALE = "${toString config.user.ui.gtk.scale}"
+            '';
+          };
         };
     };
   };

--- a/nixos/user/ui/niri/zsh-autostart.nix
+++ b/nixos/user/ui/niri/zsh-autostart.nix
@@ -4,10 +4,21 @@
   ...
 }: {
   config = lib.mkIf config.user.ui.niri.enable {
-    usr.files.".config/zsh/.zprofile" = {
-      text = lib.mkAfter ''
-        #niri
-      '';
-    };
+    usr.files =
+      {
+        ".config/zsh/.zprofile" = {
+          text = lib.mkAfter ''
+            #niri
+          '';
+        };
+      }
+      // lib.optionalAttrs config.user.shell.nushell.enable {
+        ".config/nushell/login.nu" = {
+          text = lib.mkAfter ''
+            #niri
+          '';
+          clobber = true;
+        };
+      };
   };
 }

--- a/nixos/user/ui/wayland.nix
+++ b/nixos/user/ui/wayland.nix
@@ -15,22 +15,39 @@
       pkgs.hyprpicker
     ];
     usr = {
-      files = lib.optionalAttrs config.user.shell.zsh.enable {
-        ".config/zsh/.zprofile" = {
-          text = lib.mkAfter ''
-            export WLR_NO_HARDWARE_CURSORS=1
-            export NIXOS_OZONE_WL=1
-            export QT_QPA_PLATFORM=wayland
-            export ELECTRON_OZONE_PLATFORM_HINT=wayland
-            export XDG_SESSION_TYPE=wayland
-            export GDK_BACKEND=wayland
-            export SDL_VIDEODRIVER=wayland,x11
-            export CLUTTER_BACKEND=wayland
-            export GDK_DPI_SCALE=${toString config.user.ui.gtk.scale}
-          '';
-          clobber = true;
+      files =
+        lib.optionalAttrs config.user.shell.zsh.enable {
+          ".config/zsh/.zprofile" = {
+            text = lib.mkAfter ''
+              export WLR_NO_HARDWARE_CURSORS=1
+              export NIXOS_OZONE_WL=1
+              export QT_QPA_PLATFORM=wayland
+              export ELECTRON_OZONE_PLATFORM_HINT=wayland
+              export XDG_SESSION_TYPE=wayland
+              export GDK_BACKEND=wayland
+              export SDL_VIDEODRIVER=wayland,x11
+              export CLUTTER_BACKEND=wayland
+              export GDK_DPI_SCALE=${toString config.user.ui.gtk.scale}
+            '';
+            clobber = true;
+          };
+        }
+        // lib.optionalAttrs config.user.shell.nushell.enable {
+          ".config/nushell/login.nu" = {
+            text = lib.mkAfter ''
+              $env.WLR_NO_HARDWARE_CURSORS = "1"
+              $env.NIXOS_OZONE_WL = "1"
+              $env.QT_QPA_PLATFORM = "wayland"
+              $env.ELECTRON_OZONE_PLATFORM_HINT = "wayland"
+              $env.XDG_SESSION_TYPE = "wayland"
+              $env.GDK_BACKEND = "wayland"
+              $env.SDL_VIDEODRIVER = "wayland,x11"
+              $env.CLUTTER_BACKEND = "wayland"
+              $env.GDK_DPI_SCALE = "${toString config.user.ui.gtk.scale}"
+            '';
+            clobber = true;
+          };
         };
-      };
     };
   };
 }


### PR DESCRIPTION
## Summary

- Add nushell as an alternative shell with full ZSH feature parity
- New nushell modules: config, settings, aliases, functions, XDG env setup
- Shared alias/function definitions in `lib/shell/nushell/` for cross-system reuse
- Carapace completions integration with nushell
- Fix nushell startup errors (banner, alias syntax, carapace init)
- Ensure XDG and runtime directories are created on nushell startup
- Update foot terminal color section syntax (`[colors]` → `[colors-dark]`)
- Various module improvements (nh, yt-dlp, python, wayland, zellij) for nushell compatibility

## Test plan

- [x] `nh os switch` builds and activates successfully
- [x] Nushell launches without errors
- [x] Aliases and functions work correctly in nushell
- [x] Carapace completions load properly
- [x] XDG environment variables are set correctly
- [x] Foot terminal colors render correctly

---
*Created with [Claude Code](https://claude.ai/code)*