### PR TITLE
Backport patchix and Solo Leveling config from den

### DIFF
--- a/configs/users/y0usaf.nix
+++ b/configs/users/y0usaf.nix
@@ -255,6 +255,7 @@
       expedition33.enable = true;
       duet-night-abyss.enable = true;
       arc-raiders.enable = true;
+      solo-leveling-arise.enable = true;
     };
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -784,8 +784,8 @@
         ]
       },
       "locked": {
-        "lastModified": 1773458337,
-        "narHash": "sha256-tarQ8IlHPCd2YtZ31hX7WElXLTljlxlPn4rhLpRiIaw=",
+        "lastModified": 1774204382,
+        "narHash": "sha256-+RHE9X+En5LSMKgn7fRPVH1jlKN6ir65BjTev6UwIBQ=",
         "path": "/home/y0usaf/Dev/patchix",
         "type": "path"
       },

--- a/nixos/user/gaming/default.nix
+++ b/nixos/user/gaming/default.nix
@@ -14,5 +14,6 @@ _: {
     ./wukong
     ./expedition33
     ./rv-there-yet
+    ./solo-leveling-arise
   ];
 }

--- a/nixos/user/gaming/solo-leveling-arise/default.nix
+++ b/nixos/user/gaming/solo-leveling-arise/default.nix
@@ -1,0 +1,171 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  inherit (config) user;
+in {
+  options.user.gaming.solo-leveling-arise = {
+    enable = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable Solo Leveling: Arise configuration";
+    };
+  };
+
+  config = lib.mkIf user.gaming.solo-leveling-arise.enable {
+    patchix.enable = true;
+    patchix.users."${user.name}".patches."${lib.removePrefix "${user.homeDirectory}/" user.paths.steam.path}/steamapps/compatdata/2373990/pfx/user.reg" = {
+      format = "reg";
+      clobber = true;
+      value = {
+        "HKEY_CURRENT_USER\\Software\\Netmarble Corp\\sololvcsA\\options" = {
+          "KEY_GRAPHIC_OPTION_ScreenResolutionX" = {
+            type = "sz";
+            value = "2543";
+          };
+          "KEY_GRAPHIC_OPTION_ScreenResolutionY" = {
+            type = "sz";
+            value = "1418";
+          };
+          "KEY_GRAPHIC_OPTION_FullScreenMode" = {
+            type = "sz";
+            value = "0";
+          };
+          "KEY_GRAPHIC_OPTION_VSync" = {
+            type = "sz";
+            value = "0";
+          };
+          "KEY_GRAPHIC_OPTION_FrameRate" = {
+            type = "sz";
+            value = "4";
+          };
+          "KEY_GRAPHIC_OPTION_RenderScale" = {
+            type = "sz";
+            value = "1";
+          };
+          "KEY_GRAPHIC_OPTION_TextureQuality" = {
+            type = "sz";
+            value = "4";
+          };
+          "KEY_GRAPHIC_OPTION_ShadowResolution" = {
+            type = "sz";
+            value = "4096";
+          };
+          "KEY_GRAPHIC_OPTION_ShadowDistance" = {
+            type = "sz";
+            value = "150";
+          };
+          "KEY_GRAPHIC_OPTION_SoftShadowQuality" = {
+            type = "sz";
+            value = "4";
+          };
+          "KEY_GRAPHIC_OPTION_AmbientOcclusion" = {
+            type = "sz";
+            value = "4";
+          };
+          "KEY_GRAPHIC_OPTION_Reflection" = {
+            type = "sz";
+            value = "4";
+          };
+          "KEY_GRAPHIC_OPTION_VolumetricFog" = {
+            type = "sz";
+            value = "3";
+          };
+          "KEY_GRAPHIC_OPTION_PostBloomQuality" = {
+            type = "sz";
+            value = "4";
+          };
+          "KEY_GRAPHIC_OPTION_PostBlurQuality" = {
+            type = "sz";
+            value = "3";
+          };
+          "KEY_GRAPHIC_OPTION_PostDOFQuality" = {
+            type = "sz";
+            value = "4";
+          };
+          "KEY_GRAPHIC_OPTION_PostEffectOn" = {
+            type = "sz";
+            value = "1";
+          };
+          "KEY_GRAPHIC_OPTION_MotionBlurOn" = {
+            type = "sz";
+            value = "0";
+          };
+          "KEY_GRAPHIC_OPTION_DepthOfField" = {
+            type = "sz";
+            value = "0";
+          };
+          "KEY_GRAPHIC_OPTION_AntiAliasingFilter" = {
+            type = "sz";
+            value = "0";
+          };
+          "KEY_GRAPHIC_OPTION_AntiAliasingSampleCount" = {
+            type = "sz";
+            value = "1";
+          };
+          "KEY_GRAPHIC_OPTION_CharQuality" = {
+            type = "sz";
+            value = "4";
+          };
+          "KEY_GRAPHIC_OPTION_GPUAnimation" = {
+            type = "sz";
+            value = "4";
+          };
+          "KEY_GRAPHIC_OPTION_ObjectPerformance" = {
+            type = "sz";
+            value = "4";
+          };
+          "KEY_GRAPHIC_OPTION_ParticleEffectQuality" = {
+            type = "sz";
+            value = "4";
+          };
+          "KEY_GRAPHIC_OPTION_TerrainQuality" = {
+            type = "sz";
+            value = "4";
+          };
+          "KEY_GRAPHIC_OPTION_ShaderQuality" = {
+            type = "sz";
+            value = "1";
+          };
+          "KEY_GRAPHIC_OPTION_LightQuality" = {
+            type = "sz";
+            value = "0";
+          };
+          "KEY_GRAPHIC_OPTION_VoxelShadowOn" = {
+            type = "sz";
+            value = "1";
+          };
+          "KEY_GRAPHIC_OPTION_AdaptivePerformance" = {
+            type = "sz";
+            value = "0";
+          };
+          "KEY_GRAPHIC_OPTION_Upscaling_FSR" = {
+            type = "sz";
+            value = "0";
+          };
+          "KEY_GRAPHIC_OPTION_Brightness" = {
+            type = "sz";
+            value = "0.5";
+          };
+          "KEY_GRAPHIC_OPTION_ObjectDensity" = {
+            type = "sz";
+            value = "100";
+          };
+          "KEY_GRAPHIC_OPTION_GrassDistance" = {
+            type = "sz";
+            value = "90";
+          };
+          "KEY_GRAPHIC_OPTION_DecalDistance" = {
+            type = "sz";
+            value = "60";
+          };
+          "KEY_GRAPHIC_OPTION_ScreenQuality" = {
+            type = "sz";
+            value = "3";
+          };
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- refresh the locked `patchix` input to the newer Wine-registry-capable revision from `den`
- backport the Solo Leveling: Arise gaming module into the current `main` layout
- enable the Solo Leveling config for `y0usaf`

## Verification
- `git diff --check`
- `git diff --cached --check`
- `alejandra` on the touched Nix files
- targeted `nix-instantiate` checks confirming `patchix.enable = true`, the generated patch path is `.local/share/Steam/steamapps/compatdata/2373990/pfx/user.reg`, and the patch format is `reg`

## Notes
A full flake eval on `main` is currently blocked by unrelated stale local path locks for `Agent-Harness` and `strictix`, so verification stayed scoped to the backported module and lock update.